### PR TITLE
Add `apu-memory-tuner` skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,6 +9,12 @@
   },
   "plugins": [
     {
+      "name": "apu-memory-tuner",
+      "source": "./skills/apu-memory-tuner",
+      "skills": "./",
+      "description": "Inspect and tune the shared-vs-dedicated memory split (GTT / UMA Frame Buffer) on AMD Ryzen APUs so larger LLMs and image models fit on the iGPU."
+    },
+    {
       "name": "local-ai-app-integration",
       "source": "./skills/local-ai-app-integration",
       "skills": "./",

--- a/.github/ISSUE_TEMPLATE/skill-bug-or-improvement.yml
+++ b/.github/ISSUE_TEMPLATE/skill-bug-or-improvement.yml
@@ -15,6 +15,7 @@ body:
       label: Which skill?
       description: One issue per skill. Pick **Other** if it isn't listed yet.
       options:
+        - apu-memory-tuner
         - local-ai-app-integration
         - local-ai-use
         - Other (name it in the details below)

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Diagnose, configure, and tune AMD devices directly.
 
 | Skill | What it does |
 | --- | --- |
-| `apu-memory-tuner` | Inspect and tune the shared-vs-dedicated memory split (GTT / UMA Frame Buffer) on AMD Ryzen APUs so larger LLMs and image models fit on the iGPU. |
+| `apu-memory-tuner` | Inspect and tune the shared-vs-dedicated memory split (GTT / UMA Frame Buffer) on AMD Ryzen APUs. |
 | `rocm-doctor` | Detect driver / kernel / ROCm / framework mismatches and propose fixes. |
 | `mi300x-tuner` | Opinionated inference tuning for MI300X, including TunableOp, FSDP, and FlashAttention. |
 | `gfx-target-chooser` | Pick the right `gfx942` / `gfx90a` / `gfx1100` target and matching compiler flags. |

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Diagnose, configure, and tune AMD devices directly.
 
 | Skill | What it does |
 | --- | --- |
+| `apu-memory-tuner` | Inspect and tune the shared-vs-dedicated memory split (GTT / UMA Frame Buffer) on AMD Ryzen APUs so larger LLMs and image models fit on the iGPU. |
 | `rocm-doctor` | Detect driver / kernel / ROCm / framework mismatches and propose fixes. |
 | `mi300x-tuner` | Opinionated inference tuning for MI300X, including TunableOp, FSDP, and FlashAttention. |
 | `gfx-target-chooser` | Pick the right `gfx942` / `gfx90a` / `gfx1100` target and matching compiler flags. |
@@ -199,7 +200,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for step-by-step instructions, the full a
 
 ## Status
 
-This repository is in its early days. In-repo skills include `skills/local-ai-app-integration/` and `skills/local-ai-use/`, seeding the **Application integration** focus area. The Hardware-native, Cross-stack porting, and Profiling and delivery focus areas are being built out incrementally alongside manifests and CI. Expect rapid iteration. File an issue if there is a workflow you want covered, or open a PR with a skill you have been wanting to share.
+This repository is in its early days. In-repo skills include `skills/local-ai-app-integration/` and `skills/local-ai-use/`, seeding the **Application integration** focus area, and `skills/apu-memory-tuner/`, seeding the **Hardware-native** focus area. The remaining Hardware-native, Cross-stack porting, and Profiling and delivery skills are being built out incrementally alongside manifests and CI. Expect rapid iteration. File an issue if there is a workflow you want covered, or open a PR with a skill you have been wanting to share.
 
 ## License
 

--- a/skills/apu-memory-tuner/SKILL.md
+++ b/skills/apu-memory-tuner/SKILL.md
@@ -2,21 +2,19 @@
 name: apu-memory-tuner
 description: >-
   Inspects and tunes the shared-vs-dedicated memory split on AMD Ryzen APUs
-  with unified memory (UMA), so the user can run larger LLMs, do heavier
-  image generation, or reclaim RAM for the CPU without learning the
-  GART/GTT/TTM/VRAM vocabulary first. Use when the user mentions Ryzen AI,
-  Strix Halo, Strix Point, Krackan, Phoenix, Hawk Point, Ryzen AI Max,
-  gfx1150, gfx1151, gfx1152, integrated Radeon, iGPU memory, UMA Frame
-  Buffer Size, AMD Variable Graphics Memory, VGM, GTT, GART, TTM,
-  pages_limit, amd-ttm, amd-debug-tools, "shared GPU memory", "dedicated
-  GPU memory", carve-out, "not enough VRAM", "out of VRAM", "GPU OOM",
-  llama.cpp on iGPU, ROCm on APU, running large models locally on an APU,
-  or asks how much memory their integrated GPU can use, how to give the
-  iGPU more memory, how to balance memory between CPU and GPU on a unified
-  memory APU, or how to inspect / change the BIOS UMA reservation. Read-
-  only diagnostics (platform detection and current configuration) work
-  unconditionally; the tuning step works automatically on Linux via
-  `amd-ttm` and prints guided BIOS instructions on Windows.
+  with unified memory (UMA) so larger LLMs and image-gen models fit on the
+  iGPU, or so reserved GPU memory is returned to the CPU. Use when the user
+  mentions Ryzen AI, Strix Halo / Strix Point / Krackan / Phoenix / Hawk
+  Point, Ryzen AI Max, gfx1150 / gfx1151 / gfx1152, integrated Radeon, iGPU
+  memory, UMA Frame Buffer Size, AMD Variable Graphics Memory, VGM, GTT,
+  GART, TTM, pages_limit, amd-ttm, amd-debug-tools, "shared GPU memory",
+  "dedicated GPU memory", carve-out, "not enough VRAM", "out of VRAM",
+  "GPU OOM", llama.cpp on iGPU, ROCm on APU; or asks how much memory the
+  iGPU can use, how to give the iGPU more memory, how to balance memory
+  between CPU and GPU on UMA, or how to change the BIOS UMA reservation.
+  Read-only diagnostics work everywhere; tuning runs automatically on Linux
+  via `amd-ttm` and prints guided BIOS steps on Windows. Do not use for
+  discrete Radeon cards, Intel iGPUs, or Apple Silicon -- it is APU-only.
 ---
 
 # APU Memory Tuner
@@ -54,6 +52,39 @@ Use this skill when the user wants to:
 
 Do not use it for: discrete Radeon cards (no GTT/UMA on those), Apple
 Silicon (different architecture entirely), or NVIDIA/Intel GPUs.
+
+## Prerequisites
+
+State these to the user up front so a missing one doesn't surface as a
+mystery script error halfway through:
+
+- **GPU architecture**: AMD APU with integrated Radeon. Officially tuned
+  for RDNA3.5 (`gfx1150` / `gfx1151` / `gfx1152`); RDNA3 / RDNA2 APUs work
+  but with conservative profile numbers.
+- **OS**: Linux (kernel + `amd-ttm` path) or Windows (guided BIOS path).
+  macOS is not supported.
+- **Linux kernel**: see the live AMD matrix linked from `reference.md`.
+  The detection script enforces a conservative floor (mainline 6.18.4 /
+  Ubuntu HWE 6.17.0 / Ubuntu OEM 6.14.0).
+- **Linux extras**: `pipx install amd-debug-tools` for the `amd-ttm` CLI.
+  The skill prints this command but never installs it silently. Reading
+  the BIOS carve-out from `dmesg` typically requires `sudo`.
+- **Windows extras**: AMD Adrenalin Software 25.x or newer if the user
+  wants the Variable Graphics Memory slider as an alternative to BIOS.
+- **Reboot tolerance**: any tuning change requires a reboot. Don't propose
+  this skill mid-workload.
+
+Silent footguns to surface when relevant:
+
+- `HSA_OVERRIDE_GFX_VERSION` — users running ROCm/PyTorch on an APU often
+  set this to convince ROCm the iGPU is a supported target. It does not
+  affect memory tuning, but if the user reports `HIP error: invalid
+  device` after raising GTT, this env var is usually the cause, not the
+  GTT change.
+- Windows `Win32_VideoController.AdapterRAM` is a 32-bit field capped at
+  4 GiB. If the user's reported "dedicated VRAM" is exactly 4096 MB, that's
+  the WDDM truncation, not the real BIOS reservation. The real value lives
+  in Task Manager > Performance > GPU.
 
 ## The four-step flow
 
@@ -103,14 +134,20 @@ answer to one of these:
 
 | Profile | What it does | Use when the user says... |
 |---|---|---|
-| `large-models` | GTT to ~75% of RAM, BIOS VRAM at the floor (0.5 GB). | "Run a big model", "fit Llama 70B", "I keep getting OOM on the iGPU", "give the GPU as much memory as possible". |
+| `large-models` **(default)** | GTT to ~75% of RAM, BIOS VRAM at the floor (0.5 GB). | "Run a big model", "fit Llama 70B", "I keep getting OOM on the iGPU", "give the GPU as much memory as possible". |
 | `balanced` | GTT at the kernel default (~50%), 1 GB BIOS VRAM. | "I just do mixed dev work", "back to defaults", "don't waste RAM on the GPU". |
 | `graphics` | GTT at default; BIOS VRAM raised to the larger of 8 GB or 25% of RAM. | "I'm gaming", "I want a predictable framebuffer", "stuttering in games". |
 | `reset` | Revert all changes this skill made. | "Undo it", "go back to stock". |
 | `custom` | Use the explicit `--gtt-gb` / `--vram-gb` the user passed. | "I want exactly N GB". |
 
-If you are unsure, use the `AskQuestion` tool with the five options above
-labeled in plain English; do not invent a sixth.
+**Default**: if the user is here at all and didn't specify, they almost
+always want `large-models` -- that's the only profile that meaningfully
+changes the experience for the workload that brought them here (running a
+model that didn't fit). Use it unless they explicitly said gaming, said
+they want defaults, or said an exact number.
+
+If you still can't tell, use the `AskQuestion` tool with the five options
+above labeled in plain English; do not invent a sixth.
 
 ### Step 4: apply or guide
 

--- a/skills/apu-memory-tuner/SKILL.md
+++ b/skills/apu-memory-tuner/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: apu-memory-tuner
+description: >-
+  Inspects and tunes the shared-vs-dedicated memory split on AMD Ryzen APUs
+  with unified memory (UMA), so the user can run larger LLMs, do heavier
+  image generation, or reclaim RAM for the CPU without learning the
+  GART/GTT/TTM/VRAM vocabulary first. Use when the user mentions Ryzen AI,
+  Strix Halo, Strix Point, Krackan, Phoenix, Hawk Point, Ryzen AI Max,
+  gfx1150, gfx1151, gfx1152, integrated Radeon, iGPU memory, UMA Frame
+  Buffer Size, AMD Variable Graphics Memory, VGM, GTT, GART, TTM,
+  pages_limit, amd-ttm, amd-debug-tools, "shared GPU memory", "dedicated
+  GPU memory", carve-out, "not enough VRAM", "out of VRAM", "GPU OOM",
+  llama.cpp on iGPU, ROCm on APU, running large models locally on an APU,
+  or asks how much memory their integrated GPU can use, how to give the
+  iGPU more memory, how to balance memory between CPU and GPU on a unified
+  memory APU, or how to inspect / change the BIOS UMA reservation. Read-
+  only diagnostics (platform detection and current configuration) work
+  unconditionally; the tuning step works automatically on Linux via
+  `amd-ttm` and prints guided BIOS instructions on Windows.
+---
+
+# APU Memory Tuner
+
+Help the user inspect and tune the shared-vs-dedicated memory split on AMD
+Ryzen APUs with unified memory architecture (UMA). The user states intent
+("I want to run a 70B model", "I just want my games to be smooth"); this
+skill picks the numbers, explains the trade-offs, and applies the change
+where it can.
+
+## What's actually going on
+
+On a UMA APU (Strix Halo, Strix Point, Krackan, Phoenix, Hawk Point, etc.)
+the CPU and integrated Radeon share **one physical pool of DRAM**. There is
+no separate VRAM chip. Two logical knobs cut that pool up:
+
+| Knob | Where set | What it does | Reversible? |
+|---|---|---|---|
+| **Dedicated VRAM** (a.k.a. UMA Frame Buffer / carve-out / GART) | BIOS, requires reboot | Permanently reserves DRAM for the GPU. CPU can't see it. | Only via BIOS. |
+| **Shared GPU memory** (a.k.a. GTT) | Kernel/driver-managed | Dynamic, OS-reclaimable cap on how much system RAM the GPU may map at a time. | Yes; Linux: `amd-ttm`. Windows: no user knob. |
+
+Key insight the rest of this skill rests on: **"VRAM" and shared RAM run at
+the same speed on UMA**, because they're the same DRAM. So the right default
+for AI workloads is small VRAM + large GTT, not the other way around.
+
+## When to use
+
+Use this skill when the user wants to:
+
+- Run a model that doesn't fit ("out of VRAM", "GPU OOM" on an iGPU).
+- Inspect the current memory split before changing anything.
+- Move the slider toward more shared memory (LLMs, large image gen) or
+  toward more dedicated VRAM (gaming, predictable framebuffer).
+- Revert any prior changes.
+
+Do not use it for: discrete Radeon cards (no GTT/UMA on those), Apple
+Silicon (different architecture entirely), or NVIDIA/Intel GPUs.
+
+## The four-step flow
+
+Run these in order. Each one is read-only until step 4.
+
+```
+[ ] 1. Detect platform and support level
+[ ] 2. Show current configuration
+[ ] 3. Pick a profile from the user's intent
+[ ] 4. Apply (Linux) or print BIOS guidance (Windows); verify after reboot
+```
+
+### Step 1: detect platform
+
+```bash
+python scripts/detect_platform.py
+```
+
+Add `--json` for parseable output. Exit codes:
+
+| Exit | Meaning | Next action |
+|---|---|---|
+| 0 | Supported AMD APU. | Continue to Step 2. |
+| 2 | Wrong hardware (not an AMD APU, or unclassifiable). | Stop. Tell the user this skill can't help them. |
+| 3 | AMD APU but a hard prerequisite is missing (Linux kernel too old). | Stop. Tell the user the prereq and stop. Do not attempt to upgrade the kernel from this skill. |
+
+The script reports the OS, CPU, GPU LLVM target (e.g. `gfx1151`), the
+generation bucket (RDNA3.5 / RDNA3 / RDNA2 / older), total RAM, and on
+Linux the kernel version vs. the minimums in the AMD doc.
+
+### Step 2: show current configuration
+
+```bash
+python scripts/show_config.py
+```
+
+Reports current dedicated VRAM, current shared-GPU cap, total RAM, and on
+Linux the raw `pages_limit` value plus a `rocminfo` sanity-check of what
+the runtime actually sees. Note any messages it prints — Linux often needs
+`sudo` for the dmesg read of the BIOS carve-out, and Windows' `AdapterRAM`
+field is capped at 4 GiB by WDDM (real value lives in Task Manager).
+
+### Step 3: pick a profile
+
+Ask the user what they want, in workload terms, not numbers. Map their
+answer to one of these:
+
+| Profile | What it does | Use when the user says... |
+|---|---|---|
+| `large-models` | GTT to ~75% of RAM, BIOS VRAM at the floor (0.5 GB). | "Run a big model", "fit Llama 70B", "I keep getting OOM on the iGPU", "give the GPU as much memory as possible". |
+| `balanced` | GTT at the kernel default (~50%), 1 GB BIOS VRAM. | "I just do mixed dev work", "back to defaults", "don't waste RAM on the GPU". |
+| `graphics` | GTT at default; BIOS VRAM raised to the larger of 8 GB or 25% of RAM. | "I'm gaming", "I want a predictable framebuffer", "stuttering in games". |
+| `reset` | Revert all changes this skill made. | "Undo it", "go back to stock". |
+| `custom` | Use the explicit `--gtt-gb` / `--vram-gb` the user passed. | "I want exactly N GB". |
+
+If you are unsure, use the `AskQuestion` tool with the five options above
+labeled in plain English; do not invent a sixth.
+
+### Step 4: apply or guide
+
+```bash
+python scripts/apply_profile.py --profile <choice>
+```
+
+Add `--dry-run` first if the user wants to see the planned change before
+committing.
+
+What happens on each OS:
+
+- **Linux**: writes the new GTT cap via `amd-ttm --set <N>` (which persists
+  to `/etc/modprobe.d/ttm.conf`). Reboot is required; the script tells the
+  user but never reboots automatically. If `amd-ttm` is missing, the script
+  exits with a clear install hint (`pipx install amd-debug-tools`) — do not
+  install it yourself without confirming with the user.
+- **Windows**: prints step-by-step BIOS instructions for the UMA Frame
+  Buffer Size, plus a note about AMD Adrenalin's "Variable Graphics Memory"
+  slider as an alternative on supported laptops. Nothing is written to disk
+  or registry. The script never modifies BIOS for the user.
+
+Then re-run `python scripts/show_config.py` after reboot to verify.
+
+## OS-specific reality check
+
+| Capability | Linux | Windows |
+|---|---|---|
+| Inspect dedicated VRAM | Yes (`dmesg`/`journalctl`, may need sudo) | Yes (Task Manager / dxdiag; AdapterRAM is truncated) |
+| Inspect shared cap | Yes (`/sys/module/ttm/parameters/pages_limit`) | Yes (dxdiag "Shared Memory") |
+| Change shared cap automatically | Yes (`amd-ttm`) | **No** — WDDM-managed, not user-tunable |
+| Change dedicated VRAM automatically | No (BIOS only) | No (BIOS only; VGM via Adrenalin is the closest UI) |
+
+Net effect: on Windows, raising the BIOS UMA Frame Buffer Size is the only
+real way to give the GPU more memory. On Linux you almost always want to
+*lower* BIOS VRAM and raise GTT instead.
+
+## Safety rules
+
+- Never auto-reboot. Always tell the user the reboot is needed and let them
+  do it.
+- Never touch BIOS programmatically. The script prints instructions; the
+  user navigates the firmware menu.
+- Never silently install `amd-debug-tools`. Print the `pipx install` line
+  and ask before running it.
+- Never set a profile whose validation fails. The script refuses GTT
+  targets above 95% of RAM or VRAM targets above 50% of RAM.
+- Never claim a change took effect before the user has rebooted and
+  re-verified with `show_config.py`.
+
+## Verification checklist
+
+Mark this skill complete only when **all** are true:
+
+- [ ] `python scripts/detect_platform.py` exits 0.
+- [ ] `python scripts/show_config.py` reports the *new* values after the
+      reboot following Step 4.
+- [ ] The user has tried the workload that motivated the change (loaded
+      the model, launched the game) and confirmed the new headroom helps.
+- [ ] On Linux, `cat /sys/module/ttm/parameters/pages_limit` matches what
+      `apply_profile.py` reported.
+
+If any box is unchecked the change either didn't take effect or the user
+hasn't validated it yet — say so out loud rather than declaring success.
+
+## Reference
+
+For the full glossary, kernel-version matrix, per-OEM BIOS notes, profile
+math, and troubleshooting, see [reference.md](reference.md).

--- a/skills/apu-memory-tuner/SKILL.md
+++ b/skills/apu-memory-tuner/SKILL.md
@@ -178,5 +178,6 @@ hasn't validated it yet — say so out loud rather than declaring success.
 
 ## Reference
 
-For the full glossary, kernel-version matrix, per-OEM BIOS notes, profile
-math, and troubleshooting, see [reference.md](reference.md).
+For the full glossary, the link to AMD's authoritative kernel-version /
+ROCm-compatibility matrix, per-OEM BIOS notes, profile math, and
+troubleshooting, see [reference.md](reference.md).

--- a/skills/apu-memory-tuner/reference.md
+++ b/skills/apu-memory-tuner/reference.md
@@ -1,0 +1,282 @@
+# APU Memory Tuner — Reference
+
+Detailed background for the `apu-memory-tuner` skill. Read this only when
+the four-step flow in `SKILL.md` doesn't cover a decision.
+
+## Contents
+
+- [Glossary](#glossary)
+- [Linux kernel version matrix](#linux-kernel-version-matrix)
+- [Installing amd-debug-tools](#installing-amd-debug-tools)
+- [Windows BIOS hints by OEM](#windows-bios-hints-by-oem)
+- [AMD Adrenalin Variable Graphics Memory (VGM)](#amd-adrenalin-variable-graphics-memory-vgm)
+- [Profile math](#profile-math)
+- [Troubleshooting](#troubleshooting)
+- [Source](#source)
+
+---
+
+## Glossary
+
+The same physical pool of DRAM is described by half a dozen overlapping
+terms in firmware menus, AMD docs, and forum posts. They are NOT all the
+same thing.
+
+| Term | What it actually means |
+|---|---|
+| **DRAM** | The physical LPDDR5X / DDR5 sticks. There is exactly one pool on a UMA APU. |
+| **VRAM** | Marketing-speak for "memory the GPU sees". On UMA this is a *logical* concept — there is no separate VRAM chip. |
+| **Carve-out** / **UMA Frame Buffer** / **Dedicated GPU Memory** | The DRAM region the BIOS permanently reserves for the GPU at boot. Static, GPU-only, set in firmware, requires reboot. |
+| **GART** (Graphics Address Remapping Table) | Driver-internal mapping of system RAM into the kernel-mode GPU address space. Small, used for driver bookkeeping; not the user-tunable knob. |
+| **GTT** (Graphics Translation Table) | The dynamic, OS-reclaimable pool of system RAM that user processes (PyTorch, llama.cpp, games) can map into GPU virtual addresses. **This is the knob you actually want for AI workloads.** |
+| **TTM** (Translation Table Manager) | The Linux kernel subsystem that enforces the GTT cap. The cap lives at `/sys/module/ttm/parameters/pages_limit`. |
+| **Shared GPU Memory** (Windows Task Manager term) | Windows' name for the same idea as GTT. Managed by WDDM, typically capped at ~50% of RAM, **not** user-tunable. |
+| **Variable Graphics Memory (VGM)** | An AMD Adrenalin feature on supported laptops that resizes the carve-out without entering BIOS. Behaves like a soft BIOS reservation. |
+
+When the AMD doc says "VRAM", it means the carve-out. When it says "GTT",
+it means the dynamic shared pool. This skill follows the same convention.
+
+---
+
+## Linux kernel version matrix
+
+Strix Halo (gfx1151) requires Linux KFD fixes that update internal queue
+limits and memory checks. Without them, GPU compute workloads may fail to
+initialize or behave unpredictably regardless of how you set GTT.
+
+Minimum kernel versions (per the source AMD doc):
+
+| Distribution | Minimum kernel |
+|---|---|
+| Ubuntu 24.04 HWE | `6.17.0-19.19~24.04.2` |
+| Ubuntu 24.04 OEM | `6.14.0-1018` |
+| Ubuntu 26.04 (generic) | shipped |
+| Fedora 43 | shipped |
+| Arch Linux 2026.02.01 | shipped |
+| All other distributions | mainline `6.18.4` or newer |
+
+ROCm release compatibility (from the AMD doc):
+
+| ROCm release | Ubuntu 24.04 HWE / OEM / Ubuntu 26.04 | Other distros >= 6.18.4 | Other distros < 6.18.4 |
+|---|---|---|---|
+| 7.11.0 / 7.12.0 | Stable | Stable | Unstable |
+| 7.10.0 / 7.9.0 | Unsupported | Unsupported | Unstable |
+| 7.2.1 | Stable | Stable | Unstable |
+| 7.2.0 | Stable | Stable | Unsupported |
+| 7.1.x | Unsupported | Unsupported | Unstable |
+| 6.4.x | Unsupported | Unsupported | Unstable |
+
+`detect_platform.py` only enforces the **mainline 6.18.4 / Ubuntu HWE
+6.17.0 / Ubuntu OEM 6.14.0** floor. Anything below that is reported as
+`kernel_supported: false` and the skill stops.
+
+For RDNA3 / RDNA2 APUs (gfx1103, gfx1036, etc.) the kernel requirements
+are looser — any reasonably recent (6.x) kernel works for the GTT knob,
+because the new KFD fixes are Strix Halo specific. The detection script
+does not enforce a floor for those generations.
+
+---
+
+## Installing amd-debug-tools
+
+`amd-ttm` ships in the [`amd-debug-tools`](https://pypi.org/project/amd-debug-tools/)
+PyPI package, maintained by AMD.
+
+```bash
+sudo apt install pipx
+pipx ensurepath
+pipx install amd-debug-tools
+```
+
+After install, the helpers `amd-ttm`, `amd-pstate`, etc. are on the user's
+PATH. `amd-ttm --set <N>` writes a single-line modprobe override:
+
+```
+# /etc/modprobe.d/ttm.conf
+options ttm pages_limit=<N_in_pages>
+```
+
+The kernel reads this file when the `ttm` module loads, which happens
+during early boot before the amdgpu driver initializes. That's why a
+reboot is required — the live `pages_limit` cannot be raised on a running
+kernel.
+
+`amd-ttm --clear` removes the file. `amd-ttm` (no args) prints the current
+limit in pages and GB.
+
+---
+
+## Windows BIOS hints by OEM
+
+The setting is the same on every AMD platform; only the menu path differs.
+General navigation tips:
+
+| OEM | BIOS key | Typical menu path |
+|---|---|---|
+| Asus / ROG | F2 or Del | Advanced > AMD CBS > NBIO Common Options > GFX Configuration > **UMA Frame Buffer Size** |
+| HP | F10 | Advanced > Built-in Device Options > **Video Memory** (limited values) |
+| Lenovo (consumer) | F1 / F2 / Enter then F1 | Configuration / Devices > **Video Memory** |
+| Lenovo ThinkPad | F1 | Config > Display > **Total Graphics Memory** |
+| Framework (AMD) | F2 | Advanced > AMD CBS > NBIO Common Options > GFX Configuration > **UMA Frame Buffer Size** (Strix Halo / Ryzen AI Max) |
+| MSI | Del | Advanced > AMD CBS > **UMA Frame Buffer Size** |
+| Dell (consumer) | F2 | Video > **Integrated Graphics Memory** |
+| ASRock | F2 | Advanced > AMD CBS > NBIO > **UMA Frame Buffer Size** |
+
+Notes:
+
+- Some OEM BIOSes hide the slider behind an Advanced Mode toggle (Asus
+  ROG: F7 to switch from EZ Mode to Advanced).
+- Maximum value depends on installed RAM and OEM caps. Strix Halo systems
+  with 64–128 GB usually allow up to half of installed RAM as carve-out.
+- A few business laptops (esp. older Dell Latitude / HP EliteBook) hide
+  the setting entirely. On those machines, the carve-out is fixed at the
+  OEM default and your only option is AMD Adrenalin VGM (if supported).
+
+---
+
+## AMD Adrenalin Variable Graphics Memory (VGM)
+
+On supported AMD APU laptops (most Ryzen AI 300 series, Ryzen AI Max
+series), AMD Adrenalin Software exposes a **Variable Graphics Memory**
+slider:
+
+```
+Adrenalin > System > Hardware > Variable Graphics Memory
+```
+
+VGM behaves much like a BIOS carve-out — it permanently reserves DRAM for
+the GPU until you change it back — but you don't have to enter firmware.
+Trade-offs vs. setting it in BIOS:
+
+- **Pro:** No reboot to change it (some configs); no BIOS dance.
+- **Pro:** Survives Windows updates better than fragile BIOS profiles.
+- **Con:** Not all AMD APU SKUs expose VGM; OEM has to enable it.
+- **Con:** Only goes up to a per-OEM cap, sometimes lower than the BIOS
+  cap.
+
+`detect_platform.py` records the Adrenalin driver version on Windows so
+you can flag VGM as a likely-available alternative. It cannot tell whether
+the OEM enabled the feature; the user has to open Adrenalin to confirm.
+
+---
+
+## Profile math
+
+Every profile resolves to concrete (GTT, VRAM) numbers based on total RAM.
+`scripts/apply_profile.py` does this in `resolve_profile()`. The math:
+
+| Profile | GTT | VRAM | Notes |
+|---|---|---|---|
+| `large-models` | `0.75 * total_ram_gb` | `0.5` GB | Floors at 1 GB GTT, 0.5 GB VRAM. |
+| `balanced` | `0.50 * total_ram_gb` | `1.0` GB | Mirrors kernel default. |
+| `graphics` | `0.50 * total_ram_gb` | `max(8, 0.25 * total_ram_gb)` GB | Reserves enough for AAA framebuffers. |
+| `reset` | `None` | `None` | Clears amd-ttm config (Linux); BIOS instructions (Windows). |
+| `custom` | `--gtt-gb` | `--vram-gb` | Whatever the user asked for. |
+
+Worked examples (in GB):
+
+| Total RAM | large-models GTT | balanced GTT | graphics VRAM |
+|---|---|---|---|
+| 16 | 12 | 8 | 8 |
+| 32 | 24 | 16 | 8 |
+| 64 | 48 | 32 | 16 |
+| 96 | 72 | 48 | 24 |
+| 128 | 96 | 64 | 32 |
+
+Validation rules the script enforces (refuses to apply on failure):
+
+- `gtt_gb >= 1`
+- `vram_gb >= 0.5`
+- `gtt_gb <= 0.95 * total_ram_gb` (leaves 5% for kernel + CPU)
+- `vram_gb <= 0.50 * total_ram_gb` (no more than half the machine for the
+  GPU carve-out)
+
+To override these, the user must use `--profile custom` and explicitly
+pass numbers — there is no `--force` flag.
+
+---
+
+## Troubleshooting
+
+### `amd-ttm: command not found`
+
+`amd-debug-tools` is not installed. Install with:
+
+```bash
+pipx install amd-debug-tools
+```
+
+If `pipx` itself is missing: `sudo apt install pipx && pipx ensurepath`.
+
+### GTT didn't change after reboot
+
+Most common cause: `amd-ttm --set` succeeded but a *different* modprobe
+override is taking precedence. Check:
+
+```bash
+cat /etc/modprobe.d/ttm.conf
+ls /etc/modprobe.d/
+sudo update-initramfs -u   # if you have a custom initramfs
+cat /sys/module/ttm/parameters/pages_limit
+```
+
+If the live `pages_limit` doesn't match `ttm.conf`, the file isn't being
+applied — usually because another conf file under `/etc/modprobe.d/`
+overrides it, or the initramfs hasn't been regenerated.
+
+Less common: the kernel silently capped the value at total system RAM.
+The TTM subsystem will not let you map more pages than physically exist.
+
+### Windows shared GPU memory looks fixed at 50%
+
+That's WDDM. There is no user-facing knob to raise it. Your only lever is
+to raise the BIOS UMA Frame Buffer Size (carve-out) instead. This is the
+opposite of the Linux advice and is not a workaround you'd choose for AI
+workloads — it permanently steals DRAM from the CPU. But on Windows it's
+the only knob that exists.
+
+### `dmesg` returns "Operation not permitted" on Linux
+
+Recent kernels restrict dmesg to root. Either:
+
+```bash
+sudo dmesg | grep -i 'amdgpu .*VRAM'
+```
+
+or grant the current user access:
+
+```bash
+sudo sysctl kernel.dmesg_restrict=0
+```
+
+### `rocminfo` says "ROCk module is NOT loaded"
+
+The `amdkfd` kernel module isn't loaded. On most distros it auto-loads
+with the `amdgpu` driver; if it doesn't, ROCm itself isn't installed
+and the runtime cross-check is unavailable. The TTM/GTT knob still works
+without ROCm — it's a kernel-level setting, not a userspace one.
+
+### "Can I tune my discrete RX 7900 XTX with this skill?"
+
+No. Discrete GPUs have their own VRAM and don't use the GART/GTT model.
+This skill is APU-only. `detect_platform.py` will report the discrete
+card but exit `2` ("not an APU").
+
+### "Can I tune my Intel iGPU or Apple Silicon with this skill?"
+
+No. Intel iGPUs use a different (i915/Xe) memory model, and Apple Silicon
+UMA is managed entirely by macOS with no user-facing knobs. This skill
+only knows AMD.
+
+---
+
+## Source
+
+The Linux mechanics, kernel version requirements, and the recommendation
+to keep BIOS VRAM small + GTT large come from the AMD ROCm documentation:
+
+<https://rocm.docs.amd.com/en/latest/how-to/system-optimization/rdna3-5.html>
+
+The Windows mechanics are documented across AMD Adrenalin release notes
+and the WDDM developer guide on docs.microsoft.com. The OEM BIOS paths in
+the table above are observed from public BIOS manuals as of 2026.

--- a/skills/apu-memory-tuner/reference.md
+++ b/skills/apu-memory-tuner/reference.md
@@ -44,36 +44,22 @@ Strix Halo (gfx1151) requires Linux KFD fixes that update internal queue
 limits and memory checks. Without them, GPU compute workloads may fail to
 initialize or behave unpredictably regardless of how you set GTT.
 
-Minimum kernel versions (per the source AMD doc):
+The exact minimum kernel versions per distribution and the ROCm release
+compatibility matrix change every few months as backports land. Both live
+authoritatively at:
 
-| Distribution | Minimum kernel |
-|---|---|
-| Ubuntu 24.04 HWE | `6.17.0-19.19~24.04.2` |
-| Ubuntu 24.04 OEM | `6.14.0-1018` |
-| Ubuntu 26.04 (generic) | shipped |
-| Fedora 43 | shipped |
-| Arch Linux 2026.02.01 | shipped |
-| All other distributions | mainline `6.18.4` or newer |
+> [AMD RDNA3.5 system optimization > Operating system support](https://rocm.docs.amd.com/en/latest/how-to/system-optimization/rdna3-5.html#operating-system-support)
 
-ROCm release compatibility (from the AMD doc):
+Always check that page rather than trusting a copy here. `detect_platform.py`
+hardcodes a single conservative floor (mainline 6.18.4 / Ubuntu HWE 6.17.0 /
+Ubuntu OEM 6.14.0) for its programmatic gate; if the AMD page diverges from
+that, prefer the AMD page and update the script's `LINUX_KERNEL_MIN_*`
+constants.
 
-| ROCm release | Ubuntu 24.04 HWE / OEM / Ubuntu 26.04 | Other distros >= 6.18.4 | Other distros < 6.18.4 |
-|---|---|---|---|
-| 7.11.0 / 7.12.0 | Stable | Stable | Unstable |
-| 7.10.0 / 7.9.0 | Unsupported | Unsupported | Unstable |
-| 7.2.1 | Stable | Stable | Unstable |
-| 7.2.0 | Stable | Stable | Unsupported |
-| 7.1.x | Unsupported | Unsupported | Unstable |
-| 6.4.x | Unsupported | Unsupported | Unstable |
-
-`detect_platform.py` only enforces the **mainline 6.18.4 / Ubuntu HWE
-6.17.0 / Ubuntu OEM 6.14.0** floor. Anything below that is reported as
-`kernel_supported: false` and the skill stops.
-
-For RDNA3 / RDNA2 APUs (gfx1103, gfx1036, etc.) the kernel requirements
-are looser — any reasonably recent (6.x) kernel works for the GTT knob,
-because the new KFD fixes are Strix Halo specific. The detection script
-does not enforce a floor for those generations.
+For RDNA3 / RDNA2 APUs (gfx1103, gfx1036, etc.) the kernel requirements are
+looser — any reasonably recent (6.x) kernel works for the GTT knob, because
+the new KFD fixes are Strix Halo specific. The detection script does not
+enforce a floor for those generations.
 
 ---
 

--- a/skills/apu-memory-tuner/scripts/apply_profile.py
+++ b/skills/apu-memory-tuner/scripts/apply_profile.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env -S uv run --quiet
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""Apply an AMD APU memory tuning profile, or print BIOS guidance.
+
+Usage:
+    python scripts/apply_profile.py --profile large-models
+    python scripts/apply_profile.py --profile balanced
+    python scripts/apply_profile.py --profile graphics
+    python scripts/apply_profile.py --profile reset
+    python scripts/apply_profile.py --profile custom --gtt-gb 100 --vram-gb 0.5
+    python scripts/apply_profile.py --profile large-models --dry-run
+
+Profiles map the user's high-level intent to concrete numbers:
+
+  large-models  Maximum shared GPU memory; minimum BIOS carve-out.
+                For LLM inference, large image-gen, training.
+                GTT  = 75% of total RAM.
+                VRAM = 0.5 GB (smallest most BIOSes allow).
+
+  balanced      Default-ish split for mixed dev work.
+                GTT  = 50% of total RAM (kernel default).
+                VRAM = 1 GB.
+
+  graphics      Reserve more VRAM for predictable framebuffer (gaming).
+                GTT  = 50% of total RAM.
+                VRAM = max(8, total_ram * 0.25) GB.
+
+  reset         Revert any change this skill made.
+                Linux: `amd-ttm --clear`.
+                Windows: instruct user to set UMA Frame Buffer Size to Auto.
+
+  custom        Use the explicit --gtt-gb / --vram-gb the user passed.
+
+What this script CAN do automatically:
+  Linux: run `amd-ttm --set <N>` (writes /etc/modprobe.d/ttm.conf).
+         Reboot is still needed; we never auto-reboot.
+
+What this script will NEVER do:
+  - Modify or flash BIOS / firmware.
+  - Edit Windows registry keys controlling VRAM (driver-managed and risky).
+  - Reboot the machine.
+  - Install packages without an explicit confirmation flag.
+
+For BIOS-side changes (the only knob for the dedicated VRAM carve-out on
+both OSes), this script prints step-by-step instructions and exits.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+PAGE_SIZE_BYTES = 4096
+MIN_VRAM_GB = 0.5    # Floor most BIOSes allow for the UMA frame buffer.
+MIN_GTT_GB = 1.0     # Below this, even routine GPU work fails.
+
+# `amd-ttm` ships in the `amd-debug-tools` PyPI package. We never install
+# silently; instead we print this command for the user to run.
+AMD_TTM_INSTALL_CMD = "pipx install amd-debug-tools"
+
+
+@dataclass
+class ProfileTargets:
+    name: str
+    gtt_gb: float | None       # None = leave alone (graphics keeps default)
+    vram_gb: float | None      # None = leave at firmware default
+    rationale: str
+
+
+def _run(cmd: list[str], timeout: float = 60.0) -> tuple[int, str, str]:
+    try:
+        r = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout, check=False,
+        )
+        return r.returncode, r.stdout or "", r.stderr or ""
+    except (FileNotFoundError, subprocess.SubprocessError, OSError) as e:
+        return 127, "", str(e)
+
+
+def _read_text(path: str) -> str:
+    try:
+        return Path(path).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
+def _total_ram_gb_linux() -> float | None:
+    txt = _read_text("/proc/meminfo")
+    m = re.search(r"^MemTotal:\s+(\d+)\s+kB", txt, re.MULTILINE)
+    return round(int(m.group(1)) / (1024 * 1024), 2) if m else None
+
+
+def _total_ram_gb_windows() -> float | None:
+    rc, out, _ = _run([
+        "powershell", "-NoProfile", "-Command",
+        "(Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory",
+    ], timeout=8)
+    if rc == 0 and out.strip().isdigit():
+        return round(int(out.strip()) / (1024 ** 3), 2)
+    return None
+
+
+def total_ram_gb() -> float | None:
+    sysname = platform.system().lower()
+    if sysname == "linux":
+        return _total_ram_gb_linux()
+    if sysname == "windows":
+        return _total_ram_gb_windows()
+    return None
+
+
+def resolve_profile(
+    name: str,
+    total_gb: float | None,
+    custom_gtt: float | None,
+    custom_vram: float | None,
+) -> ProfileTargets:
+    """Map a profile name + system RAM into concrete GTT/VRAM targets.
+
+    `total_gb` is required for the percentage-based profiles. If we don't
+    know it, we degrade to a conservative absolute number (16 GB GTT) so the
+    user still gets a useful suggestion, and we annotate the rationale.
+    """
+    if name == "custom":
+        return ProfileTargets(
+            name="custom",
+            gtt_gb=custom_gtt,
+            vram_gb=custom_vram,
+            rationale="User-specified values.",
+        )
+
+    if name == "reset":
+        return ProfileTargets(
+            name="reset",
+            gtt_gb=None,
+            vram_gb=None,
+            rationale="Revert to firmware/kernel defaults.",
+        )
+
+    if total_gb is None:
+        # Fallback when /proc/meminfo or CIM probe failed. Better to give a
+        # reasonable absolute number than to crash; the user can override with
+        # --profile custom.
+        if name == "large-models":
+            return ProfileTargets(
+                "large-models", 32.0, MIN_VRAM_GB,
+                "Total RAM unknown; falling back to 32 GB GTT, 0.5 GB VRAM.",
+            )
+        if name == "balanced":
+            return ProfileTargets(
+                "balanced", 16.0, 1.0,
+                "Total RAM unknown; falling back to 16 GB GTT, 1 GB VRAM.",
+            )
+        if name == "graphics":
+            return ProfileTargets(
+                "graphics", None, 8.0,
+                "Total RAM unknown; reserving 8 GB VRAM, leaving GTT at default.",
+            )
+
+    if name == "large-models":
+        return ProfileTargets(
+            "large-models",
+            gtt_gb=round(total_gb * 0.75, 1),
+            vram_gb=MIN_VRAM_GB,
+            rationale=(
+                f"75% of {total_gb:.0f} GB RAM as GTT, minimum BIOS carve-out. "
+                "Maximizes memory available to LLMs, image-gen, training."
+            ),
+        )
+    if name == "balanced":
+        return ProfileTargets(
+            "balanced",
+            gtt_gb=round(total_gb * 0.50, 1),
+            vram_gb=1.0,
+            rationale=(
+                f"50% of {total_gb:.0f} GB RAM as GTT, 1 GB BIOS carve-out. "
+                "Mirrors kernel/driver defaults; good for mixed dev work."
+            ),
+        )
+    if name == "graphics":
+        vram = max(8.0, round(total_gb * 0.25, 1))
+        return ProfileTargets(
+            "graphics",
+            gtt_gb=round(total_gb * 0.50, 1),
+            vram_gb=vram,
+            rationale=(
+                f"{vram:.0f} GB BIOS carve-out for predictable framebuffer; "
+                "GTT left near default. Tuned for gaming."
+            ),
+        )
+    raise ValueError(f"Unknown profile: {name}")
+
+
+def _validate_targets(t: ProfileTargets, total_gb: float | None) -> list[str]:
+    errs: list[str] = []
+    if t.gtt_gb is not None and t.gtt_gb < MIN_GTT_GB:
+        errs.append(f"GTT target {t.gtt_gb} GB is below the {MIN_GTT_GB} GB floor.")
+    if t.vram_gb is not None and t.vram_gb < MIN_VRAM_GB:
+        errs.append(
+            f"VRAM target {t.vram_gb} GB is below the {MIN_VRAM_GB} GB floor "
+            "most BIOSes allow."
+        )
+    if total_gb is not None and t.gtt_gb is not None and t.gtt_gb > total_gb * 0.95:
+        errs.append(
+            f"GTT target {t.gtt_gb} GB is >95% of total RAM ({total_gb} GB); "
+            "leaves no headroom for the kernel and CPU processes."
+        )
+    if total_gb is not None and t.vram_gb is not None and t.vram_gb > total_gb * 0.5:
+        errs.append(
+            f"VRAM target {t.vram_gb} GB is >50% of total RAM ({total_gb} GB); "
+            "permanently reserves more than half the machine for the GPU."
+        )
+    return errs
+
+
+def _print_targets(t: ProfileTargets) -> None:
+    print(f"Profile:    {t.name}")
+    print(f"Rationale:  {t.rationale}")
+    print(f"Target GTT: {t.gtt_gb if t.gtt_gb is not None else 'unchanged'}"
+          + (" GB" if t.gtt_gb is not None else ""))
+    print(f"Target VRAM (BIOS carve-out): "
+          + (f"{t.vram_gb} GB" if t.vram_gb is not None else "unchanged"))
+    print()
+
+
+def apply_linux(t: ProfileTargets, dry_run: bool) -> int:
+    """Apply the GTT half on Linux via amd-ttm; print VRAM-side guidance."""
+    if t.name == "reset":
+        if shutil.which("amd-ttm") is None:
+            print("amd-ttm not found; nothing to revert. Install with:")
+            print(f"  {AMD_TTM_INSTALL_CMD}")
+            return 0
+        cmd = ["amd-ttm", "--clear"]
+        print("Will run:", " ".join(cmd))
+        if dry_run:
+            print("(dry-run; not executed)")
+            return 0
+        rc, out, err = _run(cmd, timeout=15)
+        sys.stdout.write(out)
+        sys.stderr.write(err)
+        if rc == 0:
+            print("Reverted. Reboot for the kernel to pick up the default.")
+        return rc
+
+    if t.gtt_gb is not None:
+        if shutil.which("amd-ttm") is None:
+            print("ERROR: amd-ttm is required to set the GTT/shared cap on Linux.")
+            print("Install it with:")
+            print(f"  {AMD_TTM_INSTALL_CMD}")
+            print("Then re-run this script.")
+            return 4
+        # amd-ttm takes integer GB; round down so we never silently overshoot
+        # into a value the kernel rejects on the next boot.
+        gb_int = int(t.gtt_gb)
+        cmd = ["amd-ttm", "--set", str(gb_int)]
+        print("Will run:", " ".join(cmd))
+        if dry_run:
+            print("(dry-run; not executed)")
+        else:
+            rc, out, err = _run(cmd, timeout=15)
+            sys.stdout.write(out)
+            sys.stderr.write(err)
+            if rc != 0:
+                print(f"amd-ttm exited {rc}; the change was NOT persisted.")
+                return rc
+            print(
+                f"GTT/shared cap set to {gb_int} GB. "
+                "Reboot for the change to take effect."
+            )
+
+    if t.vram_gb is not None:
+        print()
+        print("BIOS-side change required for the dedicated VRAM carve-out:")
+        print(f"  Set 'UMA Frame Buffer Size' (or equivalent) to {t.vram_gb} GB")
+        print("  in the BIOS. Reboot, then re-run scripts/show_config.py")
+        print("  to verify.")
+        print()
+        print("Common BIOS paths:")
+        print("  Advanced > AMD CBS > NBIO Common Options > GFX Configuration > UMA Frame Buffer Size")
+        print("  Advanced > AMD Overclocking > UMA Frame Buffer Size")
+        print()
+        print("This script will NOT change BIOS for you.")
+    return 0
+
+
+def apply_windows(t: ProfileTargets, dry_run: bool) -> int:
+    """Windows is BIOS-only for the meaningful knobs; print guidance."""
+    if t.name == "reset":
+        print("To revert APU memory settings on Windows:")
+        print("  1. Reboot and enter BIOS (Del/F2/F10 depending on OEM).")
+        print("  2. Set 'UMA Frame Buffer Size' back to 'Auto' (or your")
+        print("     OEM's default).")
+        print("  3. Save & exit.")
+        print("  4. If you previously raised VRAM via AMD Adrenalin's")
+        print("     'Variable Graphics Memory' slider, set it back to default.")
+        return 0
+
+    print("Windows does not expose the GTT/shared-memory cap as a user-tunable")
+    print("knob; the WDDM driver picks it (typically ~50% of RAM). The only")
+    print("lever you have is the BIOS UMA Frame Buffer Size, which this")
+    print("script will NOT change for you.")
+    print()
+    if t.vram_gb is not None:
+        print(f"Recommended BIOS UMA Frame Buffer Size: {t.vram_gb} GB")
+    elif t.gtt_gb is not None:
+        # The user wanted more shared memory but we have nothing to set on
+        # Windows. Surface the gap honestly.
+        print(
+            f"Profile asked for {t.gtt_gb} GB shared GPU memory, but Windows "
+            "does not let you raise the WDDM shared cap directly. To get more "
+            "GPU-visible memory, raise the BIOS UMA Frame Buffer Size instead "
+            f"(suggested: {min(t.gtt_gb, 64.0)} GB)."
+        )
+    print()
+    print("BIOS steps (OEM-agnostic):")
+    print("  1. Reboot, press your BIOS key (Del/F2/F10/Esc; varies by OEM).")
+    print("  2. Find 'UMA Frame Buffer Size' (sometimes 'Dedicated GPU')")
+    print("     under one of:")
+    print("       Advanced > AMD CBS > NBIO Common Options > GFX Configuration")
+    print("       Advanced > AMD Overclocking")
+    print("       Chipset > North Bridge")
+    print("  3. Set the value, save & exit.")
+    print()
+    print("Alternative on supported AMD laptops: AMD Adrenalin Software")
+    print("(System > Hardware > Variable Graphics Memory). VGM behaves")
+    print("similarly to a BIOS carve-out and is reset on reboot if you change")
+    print("your mind.")
+    if dry_run:
+        print("(dry-run mode -- no commands were going to run on Windows anyway)")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--profile",
+        choices=["large-models", "balanced", "graphics", "reset", "custom"],
+        required=True,
+        help="High-level intent to map to concrete VRAM/GTT numbers.",
+    )
+    parser.add_argument(
+        "--gtt-gb", type=float, default=None,
+        help="Custom GTT/shared cap in GB (only for --profile custom).",
+    )
+    parser.add_argument(
+        "--vram-gb", type=float, default=None,
+        help="Custom BIOS VRAM carve-out in GB (only for --profile custom).",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Print the planned change without executing it.",
+    )
+    parser.add_argument(
+        "--json", action="store_true",
+        help="Emit machine-readable JSON of the resolved profile and exit.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.profile == "custom" and args.gtt_gb is None and args.vram_gb is None:
+        parser.error("--profile custom requires --gtt-gb and/or --vram-gb")
+
+    total_gb = total_ram_gb()
+    targets = resolve_profile(args.profile, total_gb, args.gtt_gb, args.vram_gb)
+    errs = _validate_targets(targets, total_gb)
+
+    if args.json:
+        print(json.dumps({
+            "profile": targets.name,
+            "rationale": targets.rationale,
+            "target_gtt_gb": targets.gtt_gb,
+            "target_vram_gb": targets.vram_gb,
+            "total_ram_gb": total_gb,
+            "validation_errors": errs,
+        }, indent=2))
+        return 0 if not errs else 5
+
+    _print_targets(targets)
+    if errs:
+        print("Validation failed:")
+        for e in errs:
+            print(f"  - {e}")
+        print("Refusing to apply. Use --profile custom with safer numbers.")
+        return 5
+
+    sysname = platform.system().lower()
+    if sysname == "linux":
+        rc = apply_linux(targets, args.dry_run)
+    elif sysname == "windows":
+        rc = apply_windows(targets, args.dry_run)
+    else:
+        print(f"Unsupported OS: {sysname}. This skill targets Linux and Windows.")
+        return 2
+
+    print()
+    print("To verify after reboot, run:")
+    print("  python scripts/show_config.py")
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/apu-memory-tuner/scripts/detect_platform.py
+++ b/skills/apu-memory-tuner/scripts/detect_platform.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env -S uv run --quiet
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""Detect whether this machine is a tunable AMD APU and report support level.
+
+This is the first script the `apu-memory-tuner` skill runs. It is read-only.
+It answers a single question: "can this skill help you on this machine?"
+
+It prints a human-readable summary and, with `--json`, emits a structured
+record the agent can parse to drive the next steps.
+
+Exit codes:
+  0 = supported; the rest of the skill can proceed.
+  2 = not an AMD APU, or APU generation we don't have tuning recipes for.
+  3 = AMD APU detected, but a hard prerequisite is missing (e.g. Linux
+      kernel too old). The agent should surface the reason and stop.
+
+The detection is intentionally best-effort. Failing to read one source does
+not abort the script; it just leaves the corresponding field as `None` /
+`"unknown"`. The agent should treat empty fields as "needs user
+confirmation", not "broken".
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+# Mapping from LLVM gfx target to the marketing-friendly generation bucket
+# the rest of the skill keys off. RDNA3.5 (gfx115x) is the only generation
+# the source ROCm doc describes shared-memory tuning for, so it is the only
+# generation marked "supported" here. Older APUs still expose the same TTM
+# knob but without an officially supported tuning recipe.
+GFX_TO_GENERATION: dict[str, str] = {
+    "gfx1150": "rdna35",
+    "gfx1151": "rdna35",
+    "gfx1152": "rdna35",
+    "gfx1103": "rdna3",
+    "gfx1102": "rdna3",
+    "gfx1100": "rdna3",
+    "gfx1036": "rdna2",
+    "gfx1035": "rdna2",
+    "gfx1034": "rdna2",
+    "gfx1033": "rdna2",
+}
+
+# Kernel version minimums copied from the source AMD doc:
+# https://rocm.docs.amd.com/en/latest/how-to/system-optimization/rdna3-5.html
+# Strix Halo (gfx1151) requires the KFD fixes; without them queue creation
+# and memory checks misbehave. Mainline 6.18.4 is the floor for non-Ubuntu.
+LINUX_KERNEL_MIN_MAINLINE = (6, 18, 4)
+LINUX_KERNEL_MIN_UBUNTU_HWE = (6, 17, 0)
+LINUX_KERNEL_MIN_UBUNTU_OEM = (6, 14, 0)
+
+
+@dataclass
+class Detection:
+    os_family: str = "unknown"          # linux | windows | other
+    os_version: str = ""
+    cpu_vendor: str = "unknown"
+    cpu_model: str = ""
+    gpu_name: str = ""
+    gfx_target: str = ""                # e.g. gfx1151
+    generation: str = "unknown"         # rdna35 | rdna3 | rdna2 | older | not-amd-apu | unknown
+    is_apu: bool | None = None
+    total_ram_gb: float | None = None
+    kernel_version: str = ""            # Linux only
+    kernel_supported: bool | None = None  # Linux only
+    amd_ttm_present: bool | None = None   # Linux only
+    adrenalin_version: str = ""           # Windows only
+    supported: bool = False
+    reasons: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+
+def _run(cmd: list[str], timeout: float = 5.0) -> tuple[int, str, str]:
+    """Run a command; return (exit, stdout, stderr). Never raises."""
+    try:
+        r = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout, check=False,
+        )
+        return r.returncode, r.stdout or "", r.stderr or ""
+    except (FileNotFoundError, subprocess.SubprocessError, OSError):
+        return 127, "", ""
+
+
+def _read_text(path: str) -> str:
+    try:
+        return Path(path).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
+def _total_ram_gb_linux() -> float | None:
+    txt = _read_text("/proc/meminfo")
+    m = re.search(r"^MemTotal:\s+(\d+)\s+kB", txt, re.MULTILINE)
+    if not m:
+        return None
+    return round(int(m.group(1)) / (1024 * 1024), 2)
+
+
+def _total_ram_gb_windows() -> float | None:
+    # `wmic` is deprecated but still ships everywhere; PowerShell CIM is the
+    # modern path. Try CIM first, fall back to wmic, then GlobalMemoryStatus
+    # via ctypes as a last resort.
+    rc, out, _ = _run([
+        "powershell", "-NoProfile", "-Command",
+        "(Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory",
+    ], timeout=8)
+    if rc == 0 and out.strip().isdigit():
+        return round(int(out.strip()) / (1024 ** 3), 2)
+
+    rc, out, _ = _run(["wmic", "ComputerSystem", "get", "TotalPhysicalMemory"])
+    if rc == 0:
+        for line in out.splitlines():
+            line = line.strip()
+            if line.isdigit():
+                return round(int(line) / (1024 ** 3), 2)
+
+    try:
+        import ctypes
+
+        class MEMORYSTATUSEX(ctypes.Structure):
+            _fields_ = [
+                ("dwLength", ctypes.c_ulong),
+                ("dwMemoryLoad", ctypes.c_ulong),
+                ("ullTotalPhys", ctypes.c_ulonglong),
+                ("ullAvailPhys", ctypes.c_ulonglong),
+                ("ullTotalPageFile", ctypes.c_ulonglong),
+                ("ullAvailPageFile", ctypes.c_ulonglong),
+                ("ullTotalVirtual", ctypes.c_ulonglong),
+                ("ullAvailVirtual", ctypes.c_ulonglong),
+                ("sullAvailExtendedVirtual", ctypes.c_ulonglong),
+            ]
+
+        stat = MEMORYSTATUSEX()
+        stat.dwLength = ctypes.sizeof(MEMORYSTATUSEX)
+        if ctypes.windll.kernel32.GlobalMemoryStatusEx(ctypes.byref(stat)):
+            return round(stat.ullTotalPhys / (1024 ** 3), 2)
+    except (OSError, AttributeError, ImportError):
+        pass
+    return None
+
+
+def _cpu_info_linux() -> tuple[str, str]:
+    """Return (vendor, model) from /proc/cpuinfo."""
+    txt = _read_text("/proc/cpuinfo")
+    vendor = ""
+    model = ""
+    for line in txt.splitlines():
+        if not vendor and line.startswith("vendor_id"):
+            vendor = line.split(":", 1)[1].strip()
+        elif not model and line.startswith("model name"):
+            model = line.split(":", 1)[1].strip()
+        if vendor and model:
+            break
+    vendor_short = "amd" if "AMD" in vendor else ("intel" if "Intel" in vendor else vendor.lower())
+    return vendor_short, model
+
+
+def _cpu_info_windows() -> tuple[str, str]:
+    rc, out, _ = _run([
+        "powershell", "-NoProfile", "-Command",
+        "(Get-CimInstance Win32_Processor | Select-Object -First 1).Name",
+    ], timeout=8)
+    name = out.strip() if rc == 0 else ""
+    vendor = "amd" if "AMD" in name else ("intel" if "Intel" in name else "unknown")
+    return vendor, name
+
+
+def _gfx_target_from_rocminfo() -> tuple[str, str]:
+    """Return (gfx_target, gpu_name) from rocminfo if available."""
+    if shutil.which("rocminfo") is None:
+        return "", ""
+    rc, out, _ = _run(["rocminfo"], timeout=10)
+    if rc != 0:
+        return "", ""
+    gfx = ""
+    name = ""
+    in_gpu_agent = False
+    for line in out.splitlines():
+        s = line.strip()
+        if s.startswith("Device Type:"):
+            in_gpu_agent = "GPU" in s
+        if in_gpu_agent and s.startswith("Marketing Name:") and not name:
+            name = s.split(":", 1)[1].strip()
+        if in_gpu_agent and s.startswith("Name:") and s.endswith("gfx") is False:
+            val = s.split(":", 1)[1].strip()
+            if val.startswith("gfx") and not gfx:
+                gfx = val
+        if gfx and name:
+            break
+    return gfx, name
+
+
+def _gfx_target_from_sysfs() -> tuple[str, str]:
+    """Best-effort fallback when rocminfo isn't installed.
+
+    The amdgpu driver exposes the LLVM target string at
+    /sys/class/drm/card*/device/llvm_gfx_target on recent kernels.
+    """
+    try:
+        for card in sorted(Path("/sys/class/drm").glob("card[0-9]*")):
+            target_path = card / "device" / "llvm_gfx_target"
+            if target_path.exists():
+                target = target_path.read_text().strip()
+                name_path = card / "device" / "product_name"
+                name = name_path.read_text().strip() if name_path.exists() else ""
+                if target.startswith("gfx"):
+                    return target, name
+    except OSError:
+        pass
+    return "", ""
+
+
+def _gpu_info_windows() -> tuple[str, str]:
+    """Return (gfx_target_guess, gpu_name) for the AMD adapter on Windows.
+
+    Windows does not expose the LLVM gfx target the way the Linux amdgpu
+    driver does; we approximate by mapping the marketing name to a generation
+    bucket. The mapping is intentionally conservative; when in doubt we
+    return an empty gfx target and let the user confirm.
+    """
+    rc, out, _ = _run([
+        "powershell", "-NoProfile", "-Command",
+        "Get-CimInstance Win32_VideoController | Where-Object { $_.Name -like '*AMD*' -or $_.Name -like '*Radeon*' } | Select-Object -ExpandProperty Name",
+    ], timeout=8)
+    if rc != 0 or not out.strip():
+        return "", ""
+    name = out.strip().splitlines()[0].strip()
+    lname = name.lower()
+    # Heuristic mapping for known APU marketing names. Any miss falls through
+    # to "unknown gfx target", which downstream code treats as "ask the user".
+    if "ryzen ai max" in lname or "strix halo" in lname:
+        return "gfx1151", name
+    if "radeon 880m" in lname or "radeon 890m" in lname or "strix" in lname:
+        return "gfx1150", name
+    if "radeon 780m" in lname or "radeon 760m" in lname or "phoenix" in lname or "hawk point" in lname:
+        return "gfx1103", name
+    return "", name
+
+
+def _kernel_version_linux() -> str:
+    return platform.release()
+
+
+def _parse_kernel_tuple(v: str) -> tuple[int, int, int]:
+    """Extract (major, minor, patch) from a Linux kernel release string.
+
+    Examples:
+      "6.17.0-19-generic"   -> (6, 17, 0)
+      "6.18.4"              -> (6, 18, 4)
+      "6.14.0-1018-oem"     -> (6, 14, 0)
+    """
+    m = re.match(r"^(\d+)\.(\d+)\.(\d+)", v)
+    if not m:
+        return (0, 0, 0)
+    return (int(m.group(1)), int(m.group(2)), int(m.group(3)))
+
+
+def _kernel_supported(release: str) -> bool:
+    """Apply the version matrix from the source ROCm doc.
+
+    We accept the kernel if it meets ANY of:
+      - Mainline >= 6.18.4
+      - Ubuntu HWE >= 6.17.0 (HWE kernels carry the backport)
+      - Ubuntu OEM >= 6.14.0 (OEM kernels carry the backport)
+    """
+    tup = _parse_kernel_tuple(release)
+    if tup >= LINUX_KERNEL_MIN_MAINLINE:
+        return True
+    if "generic" in release and tup >= LINUX_KERNEL_MIN_UBUNTU_HWE:
+        return True
+    if "oem" in release and tup >= LINUX_KERNEL_MIN_UBUNTU_OEM:
+        return True
+    return False
+
+
+def _adrenalin_version_windows() -> str:
+    """Best-effort probe of the AMD Adrenalin driver version from the registry.
+
+    Adrenalin writes its version under HKLM\\SOFTWARE\\AMD\\CN\\<...>; the
+    exact key drifts across releases, so we shell out to PowerShell rather
+    than encode a registry path that will rot.
+    """
+    rc, out, _ = _run([
+        "powershell", "-NoProfile", "-Command",
+        "(Get-CimInstance Win32_VideoController | Where-Object { $_.Name -like '*AMD*' -or $_.Name -like '*Radeon*' } | Select-Object -First 1).DriverVersion",
+    ], timeout=8)
+    return out.strip() if rc == 0 else ""
+
+
+def detect() -> Detection:
+    d = Detection()
+    sysname = platform.system().lower()
+    d.os_version = platform.platform()
+
+    if sysname == "linux":
+        d.os_family = "linux"
+        d.cpu_vendor, d.cpu_model = _cpu_info_linux()
+        d.total_ram_gb = _total_ram_gb_linux()
+        d.kernel_version = _kernel_version_linux()
+        d.kernel_supported = _kernel_supported(d.kernel_version)
+        d.amd_ttm_present = shutil.which("amd-ttm") is not None
+        gfx, gpu = _gfx_target_from_rocminfo()
+        if not gfx:
+            gfx, gpu = _gfx_target_from_sysfs()
+        d.gfx_target, d.gpu_name = gfx, gpu
+    elif sysname == "windows":
+        d.os_family = "windows"
+        d.cpu_vendor, d.cpu_model = _cpu_info_windows()
+        d.total_ram_gb = _total_ram_gb_windows()
+        d.gfx_target, d.gpu_name = _gpu_info_windows()
+        d.adrenalin_version = _adrenalin_version_windows()
+    else:
+        d.os_family = "other"
+        d.reasons.append(
+            f"Unsupported OS family: {sysname}. This skill targets Linux and Windows."
+        )
+        return d
+
+    # Generation classification
+    if d.gfx_target in GFX_TO_GENERATION:
+        d.generation = GFX_TO_GENERATION[d.gfx_target]
+    elif d.gfx_target.startswith("gfx10"):
+        d.generation = "older"
+    elif d.cpu_vendor != "amd":
+        d.generation = "not-amd-apu"
+    else:
+        d.generation = "unknown"
+
+    # An APU has the GPU and CPU on the same package. We can't read that
+    # directly without DMI; use a proxy: AMD CPU + integrated Radeon string,
+    # or a known APU gfx target.
+    if d.generation in {"rdna35", "rdna3", "rdna2"}:
+        d.is_apu = True
+    elif "radeon" in d.gpu_name.lower() and d.cpu_vendor == "amd":
+        d.is_apu = True
+    else:
+        d.is_apu = False
+
+    # Decide overall supported flag and surface reasons.
+    if d.cpu_vendor != "amd":
+        d.reasons.append("CPU is not AMD; this skill only tunes AMD APUs.")
+    elif not d.is_apu:
+        d.reasons.append(
+            "No AMD APU detected. This skill is APU-only (it does not tune "
+            "discrete Radeon GPUs)."
+        )
+    elif d.generation == "rdna35":
+        d.supported = True
+    elif d.generation in {"rdna3", "rdna2"}:
+        d.supported = True
+        d.notes.append(
+            f"Detected {d.generation.upper()} APU. Tuning will work, but the "
+            "official AMD recipe targets RDNA3.5; recommended GTT/VRAM splits "
+            "may be conservative."
+        )
+    else:
+        d.reasons.append(
+            f"AMD GPU detected ({d.gpu_name or 'unknown'}) but the generation "
+            "could not be classified. Run `rocminfo` (Linux) or share the "
+            "Adapter name (Windows) so the skill can confirm."
+        )
+
+    if d.os_family == "linux" and d.supported and d.kernel_supported is False:
+        d.supported = False
+        d.reasons.append(
+            f"Linux kernel {d.kernel_version} is below the minimum required "
+            f"for RDNA3.5 ({'.'.join(map(str, LINUX_KERNEL_MIN_MAINLINE))} "
+            f"mainline, {'.'.join(map(str, LINUX_KERNEL_MIN_UBUNTU_HWE))} "
+            "Ubuntu HWE, or "
+            f"{'.'.join(map(str, LINUX_KERNEL_MIN_UBUNTU_OEM))} Ubuntu OEM). "
+            "Upgrade the kernel before tuning."
+        )
+
+    if d.os_family == "linux" and d.supported and d.amd_ttm_present is False:
+        d.notes.append(
+            "`amd-ttm` is not on PATH. Apply step will install it on demand "
+            "via `pipx install amd-debug-tools`."
+        )
+
+    return d
+
+
+def _print_human(d: Detection) -> None:
+    print("APU memory tuner -- platform detection")
+    print("-" * 40)
+    print(f"OS:                {d.os_family} ({d.os_version})")
+    print(f"CPU:               {d.cpu_model or 'unknown'} (vendor: {d.cpu_vendor})")
+    print(f"GPU:               {d.gpu_name or 'unknown'}")
+    print(f"GFX target:        {d.gfx_target or 'unknown'}")
+    print(f"Generation:        {d.generation}")
+    print(f"APU:               {d.is_apu}")
+    print(f"Total RAM:         {d.total_ram_gb if d.total_ram_gb is not None else 'unknown'} GB")
+    if d.os_family == "linux":
+        print(f"Kernel:            {d.kernel_version} (supported: {d.kernel_supported})")
+        print(f"amd-ttm on PATH:   {d.amd_ttm_present}")
+    if d.os_family == "windows":
+        print(f"Adrenalin driver:  {d.adrenalin_version or 'unknown'}")
+    print()
+    print(f"Supported by skill: {'YES' if d.supported else 'NO'}")
+    for reason in d.reasons:
+        print(f"  - {reason}")
+    for note in d.notes:
+        print(f"  note: {note}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON instead of the human summary.",
+    )
+    args = parser.parse_args(argv)
+
+    d = detect()
+
+    if args.json:
+        print(json.dumps(asdict(d), indent=2))
+    else:
+        _print_human(d)
+
+    if not d.supported:
+        # Distinguish "wrong hardware" (exit 2) from "right hardware, missing
+        # prereq" (exit 3) so the agent can pick the right next step.
+        if any("kernel" in r.lower() for r in d.reasons):
+            return 3
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/apu-memory-tuner/scripts/detect_platform.py
+++ b/skills/apu-memory-tuner/scripts/detect_platform.py
@@ -54,10 +54,12 @@ GFX_TO_GENERATION: dict[str, str] = {
     "gfx1033": "rdna2",
 }
 
-# Kernel version minimums copied from the source AMD doc:
-# https://rocm.docs.amd.com/en/latest/how-to/system-optimization/rdna3-5.html
-# Strix Halo (gfx1151) requires the KFD fixes; without them queue creation
-# and memory checks misbehave. Mainline 6.18.4 is the floor for non-Ubuntu.
+# Kernel version floors for the Linux gate. The authoritative, up-to-date
+# matrix (per distribution + per ROCm release) lives at:
+#   https://rocm.docs.amd.com/en/latest/how-to/system-optimization/rdna3-5.html
+# Always cross-check that page before bumping these constants. Strix Halo
+# (gfx1151) requires the KFD fixes referenced there; without them queue
+# creation and memory checks misbehave.
 LINUX_KERNEL_MIN_MAINLINE = (6, 18, 4)
 LINUX_KERNEL_MIN_UBUNTU_HWE = (6, 17, 0)
 LINUX_KERNEL_MIN_UBUNTU_OEM = (6, 14, 0)

--- a/skills/apu-memory-tuner/scripts/show_config.py
+++ b/skills/apu-memory-tuner/scripts/show_config.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env -S uv run --quiet
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""Report the current shared-vs-dedicated memory split on an AMD APU.
+
+Read-only. Safe to run at any time. Used by `apu-memory-tuner` both as the
+"show me where I am" step and as the post-change verification step.
+
+On Linux it reads:
+  - /sys/module/ttm/parameters/pages_limit  (the GTT/shared cap)
+  - /proc/meminfo                            (total RAM, for percentages)
+  - dmesg lines about amdgpu VRAM            (the firmware carve-out)
+  - rocminfo Pool sizes                      (sanity check via the runtime)
+
+On Windows it reads:
+  - Win32_VideoController.AdapterRAM         (the BIOS carve-out, capped at
+                                              4 GiB by the WDDM API)
+  - dxdiag /t output                         (Dedicated + Shared Memory)
+  - Win32_ComputerSystem.TotalPhysicalMemory (total RAM)
+
+All probes are best-effort. Missing fields are reported as `unknown` rather
+than failing, because the user typically only needs one of the numbers to
+make a decision.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import re
+import shutil
+import subprocess
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+# 4 KiB is the page size assumed by the amdgpu/TTM accounting on every
+# platform we target. The kernel param is in pages, the user thinks in GB.
+PAGE_SIZE_BYTES = 4096
+
+# Windows' Win32_VideoController.AdapterRAM is a 32-bit field, so it caps at
+# 2^32 - 1 == 4294967295 bytes (~4 GiB). Anything at or above this is a
+# WDDM truncation artifact, not a real measurement; we surface that to the
+# user instead of pretending it is the real reservation.
+WIN_ADAPTER_RAM_CAP = 4_294_967_295
+
+
+@dataclass
+class Config:
+    os_family: str = "unknown"
+    total_ram_gb: float | None = None
+    dedicated_vram_gb: float | None = None
+    shared_gpu_gb: float | None = None
+    ttm_pages_limit: int | None = None      # Linux only
+    ttm_source_file: str = ""               # Linux only
+    rocminfo_global_gb: float | None = None  # Linux only
+    notes: list[str] | None = None
+
+
+def _run(cmd: list[str], timeout: float = 10.0) -> tuple[int, str, str]:
+    try:
+        r = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout, check=False,
+        )
+        return r.returncode, r.stdout or "", r.stderr or ""
+    except (FileNotFoundError, subprocess.SubprocessError, OSError):
+        return 127, "", ""
+
+
+def _read_text(path: str) -> str:
+    try:
+        return Path(path).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
+def _ttm_pages_limit() -> tuple[int | None, str]:
+    """Return (pages, source_path) for the current TTM pages_limit on Linux.
+
+    The kernel parameter lives at /sys/module/ttm/parameters/pages_limit.
+    The persisted override (if amd-ttm has set it) is in
+    /etc/modprobe.d/ttm.conf. We prefer the live value because that is what
+    the running kernel is actually enforcing.
+    """
+    live = _read_text("/sys/module/ttm/parameters/pages_limit").strip()
+    if live.isdigit():
+        return int(live), "/sys/module/ttm/parameters/pages_limit"
+    persisted = _read_text("/etc/modprobe.d/ttm.conf")
+    m = re.search(r"pages_limit\s*=\s*(\d+)", persisted)
+    if m:
+        return int(m.group(1)), "/etc/modprobe.d/ttm.conf"
+    return None, ""
+
+
+def _total_ram_gb_linux() -> float | None:
+    txt = _read_text("/proc/meminfo")
+    m = re.search(r"^MemTotal:\s+(\d+)\s+kB", txt, re.MULTILINE)
+    return round(int(m.group(1)) / (1024 * 1024), 2) if m else None
+
+
+def _vram_carveout_linux() -> float | None:
+    """Best-effort read of the BIOS VRAM carve-out from dmesg.
+
+    The amdgpu driver logs a line like:
+        amdgpu 0000:c4:00.0: amdgpu: VRAM: 512M ...
+    on init. We need root for dmesg on most distros; if the read fails we
+    return None and let the caller report "unknown".
+    """
+    rc, out, _ = _run(["dmesg"])
+    if rc != 0:
+        # Some distros restrict dmesg to root. Try journalctl as a fallback.
+        rc, out, _ = _run(["journalctl", "-k", "--no-pager"])
+        if rc != 0:
+            return None
+    for line in out.splitlines():
+        m = re.search(
+            r"amdgpu .*VRAM:\s*(\d+)([KMG])", line, re.IGNORECASE,
+        )
+        if m:
+            value = int(m.group(1))
+            unit = m.group(2).upper()
+            mult = {"K": 1 / (1024 * 1024), "M": 1 / 1024, "G": 1.0}[unit]
+            return round(value * mult, 3)
+    return None
+
+
+def _rocminfo_global_gb() -> float | None:
+    """Sum the GLOBAL pool sizes for the GPU agent reported by rocminfo.
+
+    Matches lines like `Size: 65535996 (0x3e7fffc) KB` inside a `Pool 1`
+    block whose `Segment:` is `GLOBAL`. Only counts the GPU agent's pool,
+    skipping the CPU agent.
+    """
+    if shutil.which("rocminfo") is None:
+        return None
+    rc, out, _ = _run(["rocminfo"])
+    if rc != 0:
+        return None
+    in_gpu = False
+    in_global_pool = False
+    for line in out.splitlines():
+        s = line.strip()
+        if s.startswith("Device Type:"):
+            in_gpu = "GPU" in s
+            in_global_pool = False
+        if in_gpu and s.startswith("Segment:"):
+            in_global_pool = "GLOBAL" in s
+        if in_gpu and in_global_pool and s.startswith("Size:"):
+            m = re.match(r"Size:\s+(\d+)\(.*?\)\s+KB", s) or re.match(
+                r"Size:\s+(\d+)\s+KB", s
+            )
+            if m:
+                return round(int(m.group(1)) / (1024 * 1024), 2)
+    return None
+
+
+def _query_windows_powershell(snippet: str, timeout: float = 10.0) -> str:
+    """Run a PowerShell one-liner and return stdout (stripped)."""
+    rc, out, _ = _run(["powershell", "-NoProfile", "-Command", snippet], timeout=timeout)
+    return out.strip() if rc == 0 else ""
+
+
+def _total_ram_gb_windows() -> float | None:
+    val = _query_windows_powershell(
+        "(Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory"
+    )
+    if val.isdigit():
+        return round(int(val) / (1024 ** 3), 2)
+    return None
+
+
+def _vram_carveout_windows() -> tuple[float | None, str | None]:
+    """Return (gb, note). Note explains a WDDM-truncated reading."""
+    val = _query_windows_powershell(
+        "(Get-CimInstance Win32_VideoController | "
+        "Where-Object { $_.Name -like '*AMD*' -or $_.Name -like '*Radeon*' } | "
+        "Select-Object -First 1).AdapterRAM"
+    )
+    if not val.isdigit():
+        return None, None
+    raw = int(val)
+    if raw >= WIN_ADAPTER_RAM_CAP:
+        return round(raw / (1024 ** 3), 2), (
+            "AdapterRAM is reporting the WDDM 4 GiB cap. The real BIOS "
+            "carve-out may be larger; check 'Dedicated GPU memory' in Task "
+            "Manager > Performance > GPU for the unclamped value."
+        )
+    return round(raw / (1024 ** 3), 2), None
+
+
+def _shared_gpu_gb_windows() -> float | None:
+    """Parse `dxdiag /t` for the 'Shared Memory' line.
+
+    dxdiag writes its output to a temp file we have to read back. PowerShell
+    is the cleanest way to wait on it without spinlocking.
+    """
+    snippet = (
+        "$tmp = Join-Path $env:TEMP 'apu_dxdiag.txt'; "
+        "Start-Process -FilePath dxdiag -ArgumentList '/t', $tmp -Wait; "
+        "Get-Content $tmp -Raw"
+    )
+    body = _query_windows_powershell(snippet, timeout=30.0)
+    if not body:
+        return None
+    m = re.search(r"Shared Memory:\s*(\d+(?:\.\d+)?)\s*MB", body)
+    if not m:
+        return None
+    return round(float(m.group(1)) / 1024, 2)
+
+
+def collect() -> Config:
+    cfg = Config(notes=[])
+    sysname = platform.system().lower()
+    if sysname == "linux":
+        cfg.os_family = "linux"
+        cfg.total_ram_gb = _total_ram_gb_linux()
+        pages, source = _ttm_pages_limit()
+        cfg.ttm_pages_limit = pages
+        cfg.ttm_source_file = source
+        if pages is not None:
+            cfg.shared_gpu_gb = round(pages * PAGE_SIZE_BYTES / (1024 ** 3), 2)
+        cfg.dedicated_vram_gb = _vram_carveout_linux()
+        if cfg.dedicated_vram_gb is None:
+            cfg.notes.append(
+                "Could not read the BIOS VRAM carve-out from dmesg/journalctl "
+                "(usually requires root). Try `sudo dmesg | grep VRAM`."
+            )
+        cfg.rocminfo_global_gb = _rocminfo_global_gb()
+    elif sysname == "windows":
+        cfg.os_family = "windows"
+        cfg.total_ram_gb = _total_ram_gb_windows()
+        cfg.dedicated_vram_gb, vram_note = _vram_carveout_windows()
+        if vram_note:
+            cfg.notes.append(vram_note)
+        cfg.shared_gpu_gb = _shared_gpu_gb_windows()
+        cfg.notes.append(
+            "Windows does not expose a user-tunable shared-memory cap; the "
+            "value above is the WDDM-managed limit (typically ~50% of RAM)."
+        )
+    else:
+        cfg.os_family = "other"
+        cfg.notes.append(f"Unsupported OS family: {sysname}.")
+    return cfg
+
+
+def _fmt_gb(value: float | None) -> str:
+    return f"{value:.2f} GB" if isinstance(value, (int, float)) else "unknown"
+
+
+def _print_human(c: Config) -> None:
+    print("APU memory tuner -- current configuration")
+    print("-" * 40)
+    print(f"OS:                  {c.os_family}")
+    print(f"Total RAM:           {_fmt_gb(c.total_ram_gb)}")
+    print(f"Dedicated VRAM:      {_fmt_gb(c.dedicated_vram_gb)}  (BIOS carve-out, static)")
+    print(f"Shared GPU memory:   {_fmt_gb(c.shared_gpu_gb)}  (GTT/WDDM cap, dynamic)")
+    if c.os_family == "linux":
+        if c.ttm_pages_limit is not None:
+            print(
+                f"TTM pages_limit:     {c.ttm_pages_limit} pages "
+                f"(source: {c.ttm_source_file})"
+            )
+        else:
+            print("TTM pages_limit:     unknown")
+        if c.rocminfo_global_gb is not None:
+            print(f"rocminfo GPU pool:   {_fmt_gb(c.rocminfo_global_gb)}  (runtime sanity check)")
+
+    print()
+    if c.total_ram_gb and (c.dedicated_vram_gb is not None or c.shared_gpu_gb is not None):
+        vram = c.dedicated_vram_gb or 0.0
+        shared = c.shared_gpu_gb or 0.0
+        cpu_only = max(c.total_ram_gb - vram, 0.0)
+        print(
+            f"Verdict: {vram:.2f} GB dedicated VRAM, {shared:.2f} GB shared, "
+            f"~{cpu_only:.2f} GB available to CPU-only workloads, "
+            f"{c.total_ram_gb:.2f} GB total."
+        )
+    for note in c.notes or []:
+        print(f"  note: {note}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON instead of the human summary.",
+    )
+    args = parser.parse_args(argv)
+    cfg = collect()
+    if args.json:
+        print(json.dumps(asdict(cfg), indent=2))
+    else:
+        _print_human(cfg)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
# Description

Adding experimental `apu-memory-tuner` skill.

This skill detects whether the user's machine is a tunable AMD APU. If the device is supported, this skil is able to help the user to:

* Understand what is the current shared/dedicated memory split
* Configure the memory allocation using high-level guidance, such as "I need to configure memory allocation to run very large language models"

