### PR TITLE
Add credibility gate to skill proposal template

### DIFF
--- a/.github/ISSUE_TEMPLATE/skill-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/skill-proposal.yml
@@ -35,6 +35,18 @@ body:
       required: true
 
   - type: dropdown
+    id: amd_only_credible
+    attributes:
+      label: Is AMD the only credible institution to create this skill?
+      description: |
+        Skills in this catalog must be ones that only AMD is uniquely positioned to author credibly (e.g. they require AMD hardware expertise, internal performance knowledge, or first-party tooling). If another institution could produce this skill just as credibly, the skill proposal will likely not be accepted.
+      options:
+        - "Yes"
+        - "No"
+    validations:
+      required: true
+
+  - type: dropdown
     id: home
     attributes:
       label: Where should this skill live?


### PR DESCRIPTION
# Description

Adds a required Yes/No dropdown to the skill proposal template asking whether AMD is the only credible institution to create the skill. Proposals answering "No" will likely be closed.