### PR TITLE
Create a walkthrough for the TraceLens analysis skill

### DIFF
--- a/skills/tracelens-analysis-orchestrator/reference.md
+++ b/skills/tracelens-analysis-orchestrator/reference.md
@@ -67,9 +67,6 @@ Use vendor-agnostic terminology throughout such as GPU kernels, collective commu
    - Options:
      1. **MI300X**
      2. **MI325X**
-     3. **MI350X**
-     4. **MI355X**
-     5. **MI455X**
    **`comparative`:** Ask: "Which platform is target trace (trace2)?" Assign `<platform2>` (`<platform2>` does not need to be one of the platform options)
 
 4. **Analysis Mode** → `<analysis_mode>`
@@ -86,30 +83,89 @@ Use vendor-agnostic terminology throughout such as GPU kernels, collective commu
 
 5. **Environment Setup**
    - Ask: "Are you running locally or on a cluster?"
-     - If **local**: No further environment questions — prefix is blank (commands run directly).
+     - If **local**: No further environment questions. TraceLens will be installed into the active Python if missing, or auto-provisioned in `<output_dir>/cache/.venv` when needed.
      - If **cluster**:
        - Ask "Which node should we use?" → `<node>`
        - Ask "Are you working in a containerized environment (e.g. Docker)?" → if yes, ask for container name → `<container>`
-       - Ask "Are you using a virtual environment?" → if yes, ask for venv path → `<venv_path>`
+       - Ask "Are you using a virtual environment?" → if yes, ask for venv path → `<venv_path>`. If no, leave `<venv_path>` empty; a venv may be auto-created during install (see below).
 
 6. **Output Directory** (Optional)
    - Ask: "Where should we save analysis results? (Press Enter for default: <trace_directory>/analysis_output)"
    - Default: Same directory as trace file, in `analysis_output/` subdirectory
+   - **Cluster note:** `<output_dir>` must be writable from the node (and container, if used) because auto-created venvs live at `<output_dir>/cache/.venv`.
 
 7. **Extension File** (Optional) → `<extension_file>`
    - Ask: "Do you have a TraceLens extension file to apply? Press Enter to skip."
    - If provided, resolve to an absolute path and assign to `<extension_file>`.
    - If skipped, set `<extension_file>` to empty (no `--extension_file` flag is added to any command).
 
-### Build and Cache Command Prefix
+### Ensure TraceLens is installed
 
-After collecting inputs, build a command template and save it to `<output_dir>/cache/cmd_prefix.txt`. Create the directory with `mkdir -p <output_dir>/cache`.
+Before building the command prefix, verify TraceLens is importable in the **target execution environment** — the same machine, container, and venv where analysis commands will run.
 
-The template uses `{CMD}` as a placeholder for the actual command.
+Create the cache directory first: `mkdir -p <output_dir>/cache`.
 
-**Cluster:** Before building the prefix, locate the TraceLens project root on the remote environment.
+Run the import check (wrap with the same local / `ssh` / `docker exec` / `source <venv_path>/bin/activate` shell you will use for analysis; do **not** include `cd <tracelens_dir>` yet):
 
-Run the following command (adjust for container if applicable):
+```bash
+python3 -c "import TraceLens; print('TRACELOK')"
+```
+
+**If import succeeds:** skip to **Resolve `<tracelens_dir>`** below.
+
+**If import fails**, install TraceLens in this order:
+
+1. **Try the current Python environment** (or the user-provided `<venv_path>` if already set):
+
+   ```bash
+   python3 -m pip install "git+https://github.com/AMD-AGI/TraceLens.git"
+   ```
+
+2. Re-run the import check.
+
+3. **If import still fails** (permission denied, `externally-managed-environment`, missing `pip`, or other install error): create an isolated venv and install there:
+   - Set `<venv_path>` to `<output_dir>/cache/.venv`
+   - Record it: `echo '<venv_path>' > <output_dir>/cache/venv_path.txt`
+   - Create and populate the venv:
+
+   ```bash
+   python3 -m venv <venv_path>
+   source <venv_path>/bin/activate
+   python3 -m pip install --upgrade pip
+   python3 -m pip install "git+https://github.com/AMD-AGI/TraceLens.git"
+   ```
+
+4. Re-run the import check. If it still fails, stop with `[DIAG:pipeline:INSTALL_FAIL]`, show the pip stderr to the user, and do **not** proceed.
+
+All install commands must use the same execution shell as analysis. Examples:
+
+```bash
+# Local
+python3 -m pip install "git+https://github.com/AMD-AGI/TraceLens.git"
+
+# Local + user venv
+source <venv_path>/bin/activate && python3 -m pip install "git+https://github.com/AMD-AGI/TraceLens.git"
+
+# Cluster + container
+ssh <node> "docker exec <container> bash -c 'python3 -m pip install \"git+https://github.com/AMD-AGI/TraceLens.git\"'"
+
+# Cluster + container + auto-created venv
+ssh <node> "docker exec <container> bash -c 'python3 -m venv <venv_path> && source <venv_path>/bin/activate && python3 -m pip install --upgrade pip && python3 -m pip install \"git+https://github.com/AMD-AGI/TraceLens.git\"'"
+```
+
+Inform the user when TraceLens was installed or when a new venv was created at `<venv_path>`.
+
+### Resolve `<tracelens_dir>`
+
+Prefer resolving from the installed package (works for `pip install` and editable installs):
+
+```bash
+python3 -c "import os, TraceLens; print(os.path.dirname(os.path.dirname(TraceLens.__file__)))"
+```
+
+This prints the parent directory of the `TraceLens` package (the directory that contains `TraceLens/Agent/...`). Assign the output to `<tracelens_dir>`.
+
+**Fallback (cluster only):** if the import-based lookup fails, search the remote filesystem:
 
 ```bash
 # Without container:
@@ -119,15 +175,24 @@ ssh <node> "find / -maxdepth 5 -type d -name 'TraceLens' 2>/dev/null | head -5"
 ssh <node> "docker exec <container> bash -c 'find / -maxdepth 5 -type d -name TraceLens 2>/dev/null | head -5'"
 ```
 
-Pick the result containing `Agent/` and strip the trailing `/TraceLens` to get `<tracelens_dir>`.
+Pick the result whose path contains `Agent/` and strip the trailing `/TraceLens` to get `<tracelens_dir>`.
 
-Build the cluster prefix using this lookup:
+### Build and Cache Command Prefix
 
-| Container | Venv | Template |
-|-----------|------|----------|
-| No | No | `ssh <node> "cd <tracelens_dir> && {CMD}"` |
-| Yes | No | `ssh <node> "docker exec <container> bash -c 'cd <tracelens_dir> && {CMD}'"` |
-| No | Yes | `ssh <node> "bash -c 'source <venv_path>/bin/activate && cd <tracelens_dir> && {CMD}'"` |
+After TraceLens is installed and `<tracelens_dir>` is resolved, build a command template and save it to `<output_dir>/cache/cmd_prefix.txt`.
+
+The template uses `{CMD}` as a placeholder for the actual command.
+
+Build the prefix using this lookup:
+
+| Scope | Container | Venv | Template |
+|-------|-----------|------|----------|
+| Local | — | No | `cd <tracelens_dir> && {CMD}` |
+| Local | — | Yes | `source <venv_path>/bin/activate && cd <tracelens_dir> && {CMD}` |
+| Cluster | No | No | `ssh <node> "cd <tracelens_dir> && {CMD}"` |
+| Cluster | Yes | No | `ssh <node> "docker exec <container> bash -c 'cd <tracelens_dir> && {CMD}'"` |
+| Cluster | No | Yes | `ssh <node> "bash -c 'source <venv_path>/bin/activate && cd <tracelens_dir> && {CMD}'"` |
+| Cluster | Yes | Yes | `ssh <node> "docker exec <container> bash -c 'source <venv_path>/bin/activate && cd <tracelens_dir> && {CMD}'"` |
 
 Write the resolved template to `<output_dir>/cache/cmd_prefix.txt`. Then validate it works:
 
@@ -135,7 +200,7 @@ Write the resolved template to `<output_dir>/cache/cmd_prefix.txt`. Then validat
 <prefix> python3 -c "import TraceLens; print('PREFIX_OK')"
 ```
 
-If this fails, inform the user with `[DIAG:pipeline:PREFIX_FAIL]` and check that `<tracelens_dir>` is the **parent** of TraceLens (not the repo root itself), verify the container/venv is accessible, rebuild, and retry. Do NOT proceed to Step 1 until validation passes.
+If this fails, inform the user with `[DIAG:pipeline:PREFIX_FAIL]` and check that `<tracelens_dir>` is the **parent** of the `TraceLens` package directory (not the repo root itself), verify TraceLens is installed in the target environment, verify the container/venv is accessible, rebuild the prefix, and retry. Do NOT proceed to Step 1 until validation passes.
 
 ### Command Execution Pattern
 

--- a/walkthroughs/README.md
+++ b/walkthroughs/README.md
@@ -10,3 +10,4 @@ Please choose a skill to get started.
 
 * [local-ai-use](./local-ai-use.md): Teach your agent how to run image generation locally.
 * [local-ai-app-integration](./local-ai-app-integration.md): Add a local AI mode to a cloud-only app.
+* [tracelens-analysis-orchestrator](./tracelens-analysis-orchestrator.md): Run agentic PyTorch profiler trace analysis and produce a prioritized performance report.

--- a/walkthroughs/tracelens-analysis-orchestrator.md
+++ b/walkthroughs/tracelens-analysis-orchestrator.md
@@ -1,0 +1,236 @@
+# AMD Skills Walkthroughs: `tracelens-analysis-orchestrator`
+
+The goal of this skill is to teach your AI agent to run the TraceLens agentic
+analysis workflow on a PyTorch trace and produce a prioritized stakeholder
+report (`analysis.md`) with recommendations for optimizing individual kernels, 
+kernel fusion opportunities, and system-level optimizations.
+
+**What you'll end up with:** a single user-facing report at
+`<output_dir>/analysis.md` — an executive summary, ranked P-items by impact score,
+and a detailed analysis section with evidence tables and resolution guidance.
+Expect this process to take 5–30 minutes depending on trace size.
+
+## Analysis modes at a glance
+
+| Mode | Traces | Best for |
+|---|---|---|
+| **Standalone** | 1 | Roofline analysis on a single trace (default) |
+| **Comparative** | 2 | Gap analysis: primary trace vs. a faster reference trace |
+
+| Workload | Standalone | Comparative |
+|---|---|---|
+| Eager (training / eager inference) | Yes | Yes |
+| Graph + capture (vLLM / SGLang) | Yes | No |
+| Graph only | No | No |
+
+For vLLM / SGLang inference traces, the canonical collection guide in
+[TraceLens Inference Analysis](https://github.com/AMD-AGI/TraceLens/blob/main/docs/Inference_analysis.md)
+provides detailed instructions about collecting traces.
+Including capture mode graphs will produce better results but may require patching vLLM or SGLang.
+
+## Prerequisites
+
+**Software**
+
+- NVM 22 or later is installed to enable NPX skills
+- An agentic runner: **Cursor** (chat or `agent` CLI) or **Claude Code**
+- Model: **Claude Opus 4.7 High** (`claude-opus-4-7-high`) — the orchestrator and
+  all 13 sub-agents are tuned for this model
+
+**Data**
+
+- A PyTorch profiler trace (`.json` or `.json.gz`) from a representative
+  steady-state window (post-warmup). A single rank's trace is sufficient for
+  per-rank analysis.
+- The **platform** of the first trace (e.g. `MI300X`, `MI325X`) — used for
+  roofline limits and hardware reference in the report
+
+## Step 1 - Understanding which skills are available
+
+* Run `claude "which skills do you see?"`. You should see a list of skills that should not include anythink related to TraceLens.
+* Make sure there is no `AGENTS.md` file on your local folder.
+
+## Step 2 — Enabling your agent to see `tracelens-analysis-orchestrator`
+
+**Claude Code** — install with the [`skills` CLI](https://github.com/vercel-labs/skills):
+
+```bash
+npx skills add amd/skills --skill tracelens-analysis-orchestrator --agent claude-code
+```
+
+**Cursor** — install the AMD Skills plugin or add the skill manually:
+
+```bash
+npx skills add amd/skills --skill tracelens-analysis-orchestrator --agent cursor
+```
+
+Confirm the skill is visible:
+
+```bash
+claude "Which skills can you see?" --model opus
+```
+
+You should now see `tracelens-analysis-orchestrator` in the list.
+
+## Step 5 — Running standalone analysis (interactive)
+
+This is the recommended first run: one trace, default analysis mode (training and
+non-vLLM/SGLang eager inference).
+
+### Cursor chat
+
+Open a Cursor chat with **Claude Opus 4.7 High** and send:
+
+```
+Follow the analysis orchestrator installed with TraceLens and run the full agentic
+analysis workflow on <path_to_trace.json>
+```
+
+When prompted, provide:
+
+| Input | Example |
+|---|---|
+| Platform | `MI300X` |
+| Analysis mode | `default` (training / eager inference) |
+| Environment | local, local+venv, cluster, or cluster+container |
+| Node / container / venv | only if running remotely |
+| Output directory | `./analysis_output` |
+
+For **vLLM / SGLang** traces, choose analysis mode `inference` and specify execution
+mode (`eager` or `graph replay + capture`). Graph replay + capture also requires a
+capture folder path.
+
+### Claude Code
+
+```bash
+claude --model opus
+```
+
+Then prompt:
+
+```
+Follow the analysis orchestrator and run the full agentic analysis workflow on
+<path_to_trace.json> with platform MI300X, analysis mode default, output to
+./analysis_output
+```
+
+Adapt the environment fields if TraceLens runs on a remote node or inside a
+container.
+
+The orchestrator will:
+
+1. Generate a TraceLens performance report
+2. Prepare per-category data (GEMM, SDPA, norm, etc.)
+3. Launch system-level and compute-kernel sub-agents **in parallel**
+4. Validate, aggregate, and write `analysis.md`
+
+This may take a while — the workflow invokes 13 specialized sub-agents.
+
+## Step 6 — Review the output
+
+The only artifact intended for end-user review is **`analysis.md`**. Everything
+else under the output directory is agent internals.
+
+```
+analysis_output/
+├── analysis.md              # Stakeholder report (read this)
+├── perf_report.xlsx         # Internal
+├── perf_report_csvs/        # Internal
+├── category_data/           # Internal
+├── system_findings/         # Internal
+├── category_findings/       # Internal
+└── metadata/                # Internal
+```
+
+Open `analysis.md` and check the structure:
+
+1. **Executive Summary** — workload characterization, metrics table, improvement chart
+2. **Compute Kernel Optimizations** — top operations and ranked P-items
+3. **Kernel Fusion Opportunities (Experimental)**
+4. **System-Level Optimizations (Experimental)**
+5. **Detailed Analysis** — per-P-item drill-down with identification, data tables,
+   reasoning, and resolution
+
+Each P-item includes `impact_score` bounds in HTML comment markers
+(`<!-- impact-begin ... -->`) that downstream optimization tools can parse
+programmatically.
+
+## Step 7 — (Optional) Comparative analysis
+
+When you have two traces from the same framework (e.g. both vLLM, both SGLang),
+run a gap analysis. Always pass the **baseline** trace as trace 1.
+
+**Cursor chat:**
+
+```
+Follow the analysis orchestrator installed with TraceLens and run the full agentic
+analysis workflow on <path_to_baseline_trace.json> and <path_to_primary_trace.json>
+```
+
+**Claude Code:**
+
+```
+Follow the analysis orchestrator and run the full agentic analysis workflow on
+<path_to_baseline_trace.json> and <path_to_primary_trace.json> with platform MI300X,
+analysis mode default, output to ./analysis_output_comparative
+```
+
+Comparative output adds per-trace perf reports (`perf_report_trace1.xlsx`,
+`perf_report_trace2.xlsx`) and gap-based impact estimates in `category_data/`.
+
+> Cross-framework comparisons (e.g. vLLM vs. SGLang) may produce misleading gap
+> estimates due to structural differences in operation call stacks.
+
+## Step 8 — (Optional) Headless runs with the Cursor `agent` CLI
+
+For batch runs or CI, install the Cursor CLI and pass all parameters inline so no
+interactive prompts are needed.
+
+```bash
+curl https://cursor.com/install -fsS | bash
+```
+
+**Local — standalone, default mode:**
+
+```bash
+agent --model claude-opus-4-7-high --print --force --trust \
+  "Follow the analysis orchestrator installed with the TraceLens pip package (look under TraceLens/Agent/Analysis/.cursor/skills/ in the package installation directory) and run the full agentic analysis workflow on <path_to_trace.json> with platform <platform>, analysis mode default, output to <output_dir>"
+```
+
+**Cluster + container — inference (vLLM/SGLang eager):**
+
+```bash
+agent --model claude-opus-4-7-high --print --force --trust \
+  "Follow the analysis orchestrator installed with the TraceLens pip package (look under TraceLens/Agent/Analysis/.cursor/skills/ in the package installation directory) and run the full agentic analysis workflow on <path_to_trace.json> with platform <platform>, analysis mode inference, execution mode eager, node <node>, container <container>, output to <output_dir>"
+```
+
+See
+[TraceLens Agent Analysis README](https://github.com/AMD-AGI/TraceLens/blob/main/TraceLens/Agent/Analysis/README.md)
+for graph replay + capture and additional CLI variants. The eval script
+`agent_evals/Analysis/eval_scripts/generate_ref.sh` in the TraceLens repo is a
+reference for batch reference generation.
+
+## Step 9 — (Optional) Try to get things done without AMD Skills
+
+Remove the added skill from your agent's skills directory and rerun the experiment
+above. Without the orchestrator skill you should see higher variance in execution
+length, token usage, and report quality. Common issues without the skill include:
+
+- Agent improvising ad-hoc trace parsing instead of running TraceLens CLI tools
+- Missing or inconsistent sub-agent workflow (system-level vs. compute-kernel tiers)
+- Report that lacks prioritized P-items, impact scores, or the three-tier structure
+- Skipped validation steps or incomplete `category_data/` preparation
+- Agent providing a generic performance essay instead of a structured `analysis.md`
+
+## Going further
+
+- **Inference profiling:** Use the TraceLens profiling skill
+  ([`magpie-benchmark-profiling`](https://github.com/AMD-AGI/TraceLens/blob/main/TraceLens/Agent/Profiling/README.md))
+  or the [`magpie-kernel-evaluator`](../skills/magpie-kernel-evaluator/SKILL.md)
+  skill to collect vLLM/SGLang traces before analysis.
+- **Optimization loop:** Parse `analysis.md` P-items and impact markers to drive
+  kernel tuning, fusion, batching, or precision narrowing, then re-profile and
+  re-run analysis to measure improvement.
+- **Upstream docs:** Full architecture, sub-agent reference, and output layout are
+  documented in the
+  [TraceLens Agent Analysis README](https://github.com/AMD-AGI/TraceLens/blob/main/TraceLens/Agent/Analysis/README.md).

--- a/walkthroughs/tracelens-analysis-orchestrator.md
+++ b/walkthroughs/tracelens-analysis-orchestrator.md
@@ -24,7 +24,7 @@ Expect this process to take 5–30 minutes depending on trace size.
 | Graph only | No | No |
 
 For vLLM / SGLang inference traces, the canonical collection guide in
-[TraceLens Inference Analysis](https://github.com/AMD-AGI/TraceLens/blob/main/docs/Inference_analysis.md)
+[TraceLens Inference Analysis](https://github.com/AMD-AGI/TraceLens/blob/main/docs_original/Inference_analysis.md)
 provides detailed instructions about collecting traces.
 Including capture mode graphs will produce better results but may require patching vLLM or SGLang.
 


### PR DESCRIPTION
Create a walkthrough for the TraceLens analysis skill
Also modifies the local copy of the skill to install TraceLens into a venv if not available - more refactoring to follow.
Was tested using cursor