### PR TITLE
Add planned hrr-replay-analysis skill to catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Run and optimize on AMD Instinct.
 | [`serving-llms-on-epyc`](skills/serving-llms-on-epyc/SKILL.md) | Serve LLMs on AMD EPYC CPUs with vLLM + zentorch, in a container (Docker/Podman) or conda. Handles CPU detection, runtime/env validation, vLLM model-support and RAM-fit checks, hardware-sized threads/KV, launch, and health verification. Single instance; reports and stops on failure. | in-repo |
 | [`magpie-kernel-evaluator`](skills/magpie-kernel-evaluator/SKILL.md) | Evaluate GPU kernel correctness and performance, compare kernel implementations, and benchmark vLLM / SGLang inference with profiling, TraceLens, and torch-trace gap analysis. | [Magpie](https://github.com/AMD-AGI/Magpie) |
 | [`tracelens-analysis-orchestrator`](skills/tracelens-analysis-orchestrator/SKILL.md) | Orchestrate modular PyTorch profiler trace analysis with TraceLens: generate perf reports, run system-level and compute-kernel subagents in parallel, and write a prioritized stakeholder report. | [TraceLens](https://github.com/AMD-AGI/TraceLens) |
+| `hrr-replay-analysis` | Record, replay, and analyze GPU workload behavior on ROCm across AMD Instinct and Radeon using HIP Record and Replay archives. | _planned_ |
 
 ## What is a skill?
 


### PR DESCRIPTION
## Summary
- Adds `hrr-replay-analysis` as a planned skill in the Server-Native catalog
- Describes HIP Record and Replay (HRR) for recording, replaying, and analyzing GPU workload behavior on ROCm across AMD Instinct and Radeon

## Test plan
- [ ] README table renders correctly
- [ ] Row follows existing `_planned_` skill format


Made with [Cursor](https://cursor.com)