### PR TITLE
Fix local-ai-app-integration: drop pip lemonade-sdk, align CLI/lemond versions

### DIFF
--- a/skills/local-ai-app-integration/SKILL.md
+++ b/skills/local-ai-app-integration/SKILL.md
@@ -250,12 +250,17 @@ vendor/lemonade/
 
 ## Step 4: Add a `lemond` launcher
 
-The launcher is a thin process supervisor. Its only jobs:
+Write the launcher as a new module named **`lemond_launcher.py`** (or
+`lemond_launcher.<ext>` for the app's language). It is a thin process
+supervisor. Its only jobs:
 
 1. Generate a fresh random API key per app launch.
 2. Pick a free localhost port.
 3. Spawn `lemond <dir> --port <port>` with `LEMONADE_API_KEY` set.
-4. Expose the chosen `port` and `key` to the rest of the app.
+4. Poll `GET http://127.0.0.1:<port>/api/v1/health` (with the Bearer key)
+   until it returns 200 — this HTTP probe, never stdout parsing, is how
+   readiness is detected.
+5. Expose the chosen `port` and `key` to the rest of the app.
 
 > **Log one line per lifecycle stage.** Build the logging in from the start —
 > not as an afterthought when something breaks. Each silent transition needs a

--- a/skills/local-ai-app-integration/SKILL.md
+++ b/skills/local-ai-app-integration/SKILL.md
@@ -228,10 +228,12 @@ vendor/lemonade/
 
 **Backend install timing — two distinct paths:**
 
-> **Packaging time** (developer machine, before bundling):
+> **Packaging time** (developer machine, before bundling). Use the lemonade
+> CLI that shipped inside `vendor/lemonade/` so it matches the bundled
+> `lemond` version (prefix with `./` or the full path):
 > ```
-> lemonade backends install llamacpp:vulkan
-> lemonade backends install flm:npu    # Windows NPU path only
+> vendor/lemonade/lemonade backends install llamacpp:vulkan
+> vendor/lemonade/lemonade backends install flm:npu    # Windows NPU path only
 > ```
 > This bakes the backend binaries into `vendor/lemonade/bin/` before the app
 > ships. `lemond` does not need to be running. Use a modern `lemonade` CLI

--- a/skills/local-ai-app-integration/SKILL.md
+++ b/skills/local-ai-app-integration/SKILL.md
@@ -300,10 +300,17 @@ return proc, key, port
 # On app exit: proc.kill() (Windows) / proc.terminate() (Unix), then wait()
 ```
 
+Readiness is always determined by polling the exact endpoint
+`GET http://127.0.0.1:<port>/api/v1/health` and checking for HTTP 200 — never
+by reading `lemond`'s stdout or stderr. Any health-check helper you write must
+hit that `/api/v1/health` path.
+
 ## Step 5: Re-point the existing client at `lemond`
 
-Change exactly two values in the app's existing client config: the base URL
-and the API key. Nothing else.
+Change three things in the app's existing client config, and nothing beyond
+these: the base URL, the API key, and the HTTP client timeout (raise it to at
+least 120 seconds — see the note below for why). Leave every other client
+setting alone.
 
 | Existing client | New `base_url` | New auth |
 |---|---|---|

--- a/skills/local-ai-app-integration/SKILL.md
+++ b/skills/local-ai-app-integration/SKILL.md
@@ -181,8 +181,14 @@ curl -L "$URL" | tar -xz --strip-components=1 -C vendor/lemonade
 
 > **`lemond` vs `lemonade` CLI:** `lemond` is the embedded server binary that
 > ships with the app. The `lemonade` CLI is a separate packaging tool used
-> only during development/build time to install backends. Install it once on
-> the developer machine with `pip install lemonade-sdk`.
+> only during development/build time to install backends. The same embeddable
+> archive unpacked above already contains a matching `lemonade[.exe]` next to
+> `lemond[.exe]`, so its version aligns with the bundled `lemond`. Do **not**
+> `pip install lemonade-sdk` to get it: the PyPI package is a separate, older
+> release line whose ports, model names, and install API do not match the
+> `lemond` bundled here, and mixing the two is a known source of silent
+> version mismatches. Keep the `lemonade` CLI, `lemond`, and the backends all
+> from the one release downloaded in this step so their versions stay aligned.
 
 The expected layout **after setup** (first run + backend install). A freshly
 unzipped package contains only `lemond[.exe]`, `lemonade[.exe]`, `LICENSE`, and
@@ -228,7 +234,9 @@ vendor/lemonade/
 > lemonade backends install flm:npu    # Windows NPU path only
 > ```
 > This bakes the backend binaries into `vendor/lemonade/bin/` before the app
-> ships. `lemond` does not need to be running.
+> ships. `lemond` does not need to be running. Use a modern `lemonade` CLI
+> whose version matches the bundled `lemond` (the copy in the archive you
+> unpacked works); do not `pip install lemonade-sdk` for it.
 >
 > **First-run / runtime** (user's machine, after `lemond` is running):
 > ```http


### PR DESCRIPTION
## What this changes

The skill told developers to get the `lemonade` packaging CLI via `pip install lemonade-sdk`. That pulls a separate, older release line whose ports, model names, and install API do not match the `lemond` bundled from the embeddable archive, causing silent version mismatches. This PR removes the pip step and points to the already-matched CLI.

---

## Files changed

| File | Change |
|---|---|
| SKILL.md | Remove `pip install lemonade-sdk`; use the archive's bundled `lemonade` CLI |

---

## Details

- "**lemond** vs **lemonade CLI**" note: the embeddable archive unpacked in Step 3 already contains a matching `lemonade[.exe]` next to `lemond[.exe]`, so its version aligns with the bundled `lemond`. Use that copy and do not `pip install lemonade-sdk`.
- Packaging-time backend step: added a note to use a modern `lemonade` CLI whose version matches the bundled `lemond`, and not to pip-install it.
- Running **lemonade** CLI operates on the vendored tree. 
    - Updated the command to install backends into `vendor/lemonade/bin/` so they actually ship with the app. 
    - Using bare `lemonade` might install the backend into the system location instead, which wouldn't get bundled.
- Fix a Step 5 contradiction that told the agent to change "nothing else" beyond base URL and API key, which caused it to skip the required 120s HTTP-client timeout. 
    - Step 5 now lists the timeout as a required change. 
- The launcher section pins the exact `/api/v1/health` readiness path so health-check helpers use it consistently.
---

## Why

- Removes the known cause of silent version mismatches (mismatched CLI vs bundled `lemond`).
- Keeps the `lemonade` CLI, `lemond`, and backends all from one release so versions stay aligned.