### PR TITLE
Move hrr-replay-analysis to Cross-Stack catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Cross-stack skills, from client to cloud.
 | `rocm-doctor` | Diagnose ROCm / PyTorch / llama.cpp failures on AMD GPUs against a fixed list of known misconfigurations. | _planned_ |
 | `hyperloom-kernel-optimizer` | Autonomously optimizes LLM inference on AMD GPUs. | _planned_ |
 | `vllm-semantic-router` | Setup a vLLM router that semantically maps your request to the best available platform. | _planned_ |
-| `hrr-replay-analysis` | Record, replay, and analyze GPU workload behavior on ROCm across AMD Instinct and Radeon using HIP Record and Replay archives. | _planned_ |
+| `hrr-replay-analysis` | Record, replay, and analyze GPU workload behavior on ROCm across AMD Instinct, Radeon, and Ryzen hardware using HIP Record and Replay archives. | _planned_ |
 
 ### Server-Native
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Cross-stack skills, from client to cloud.
 | `rocm-doctor` | Diagnose ROCm / PyTorch / llama.cpp failures on AMD GPUs against a fixed list of known misconfigurations. | _planned_ |
 | `hyperloom-kernel-optimizer` | Autonomously optimizes LLM inference on AMD GPUs. | _planned_ |
 | `vllm-semantic-router` | Setup a vLLM router that semantically maps your request to the best available platform. | _planned_ |
+| `hrr-replay-analysis` | Record, replay, and analyze GPU workload behavior on ROCm across AMD Instinct and Radeon using HIP Record and Replay archives. | _planned_ |
 
 ### Server-Native
 
@@ -94,7 +95,6 @@ Run and optimize on AMD Instinct.
 | [`serving-llms-on-epyc`](skills/serving-llms-on-epyc/SKILL.md) | Serve LLMs on AMD EPYC CPUs with vLLM + zentorch, in a container (Docker/Podman) or conda. Handles CPU detection, runtime/env validation, vLLM model-support and RAM-fit checks, hardware-sized threads/KV, launch, and health verification. Single instance; reports and stops on failure. | in-repo |
 | [`magpie-kernel-evaluator`](skills/magpie-kernel-evaluator/SKILL.md) | Evaluate GPU kernel correctness and performance, compare kernel implementations, and benchmark vLLM / SGLang inference with profiling, TraceLens, and torch-trace gap analysis. | [Magpie](https://github.com/AMD-AGI/Magpie) |
 | [`tracelens-analysis-orchestrator`](skills/tracelens-analysis-orchestrator/SKILL.md) | Orchestrate modular PyTorch profiler trace analysis with TraceLens: generate perf reports, run system-level and compute-kernel subagents in parallel, and write a prioritized stakeholder report. | [TraceLens](https://github.com/AMD-AGI/TraceLens) |
-| `hrr-replay-analysis` | Record, replay, and analyze GPU workload behavior on ROCm across AMD Instinct and Radeon using HIP Record and Replay archives. | _planned_ |
 
 ## What is a skill?
 


### PR DESCRIPTION
## Summary
- Moves the planned `hrr-replay-analysis` skill from **Server-Native** to **Cross-Stack**
- Updates the description to cover AMD Instinct, Radeon, and Ryzen hardware on ROCm

## Test plan
- [x] README table renders correctly in both sections
- [x] No duplicate `hrr-replay-analysis` rows