### PR TITLE
Add minimal SECURITY.md to point to PSIRT disclosure program

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+If you have discovered a security vulnerability in amd/skills, please do NOT report it publicly using a GitHub issue. Instead, you should report the issue via the AMD Product Security website:
+
+[https://www.amd.com/en/resources/product-security.html](https://www.amd.com/en/resources/product-security.html)
+
+In your report, please include the skill used alongside transcripts, agent / model used, and a minimal reproduction, if possible.


### PR DESCRIPTION
Projects like [ROCm/axis](https://github.com/ROCm/axis/blob/main/SECURITY.md) and [ROCm/AMDMIGraphX](https://github.com/ROCm/AMDMIGraphX/blob/develop/SECURITY.md) provide references to the Vulnerability Disclosure Program to communicate how users and contributors can safely disclose any security vulnerabilities discovered while using these libraries. `amd/skills`, should include security documentation as well.