### PR TITLE
fix(apu-memory-tuner): detect GPU when rocminfo lists Name before Device Type

### DIFF
--- a/staging/apu-memory-tuner/scripts/detect_platform.py
+++ b/staging/apu-memory-tuner/scripts/detect_platform.py
@@ -182,28 +182,39 @@ def _cpu_info_windows() -> tuple[str, str]:
 
 
 def _gfx_target_from_rocminfo() -> tuple[str, str]:
-    """Return (gfx_target, gpu_name) from rocminfo if available."""
+    """Return (gfx_target, gpu_name) from rocminfo if available.
+
+    rocminfo prints one block per agent, and WITHIN a block the ``Name:`` and
+    ``Marketing Name:`` lines appear *before* the ``Device Type:`` line. So we
+    can't wait until we've seen ``Device Type: GPU`` to start capturing -- by
+    then those lines are already behind us. Instead we buffer the current
+    block's candidate gfx target + marketing name and commit them the moment we
+    confirm the block is a GPU. A new ``Agent N`` header resets the buffer.
+    """
     if shutil.which("rocminfo") is None:
         return "", ""
     rc, out, _ = _run(["rocminfo"], timeout=10)
     if rc != 0:
         return "", ""
-    gfx = ""
-    name = ""
-    in_gpu_agent = False
+    cand_gfx = ""
+    cand_name = ""
     for line in out.splitlines():
         s = line.strip()
-        if s.startswith("Device Type:"):
-            in_gpu_agent = "GPU" in s
-        if in_gpu_agent and s.startswith("Marketing Name:") and not name:
-            name = s.split(":", 1)[1].strip()
-        if in_gpu_agent and s.startswith("Name:") and s.endswith("gfx") is False:
+        if s.startswith("Agent ") and s[len("Agent "):].strip().isdigit():
+            cand_gfx = ""
+            cand_name = ""
+        elif s.startswith("Name:"):
             val = s.split(":", 1)[1].strip()
-            if val.startswith("gfx") and not gfx:
-                gfx = val
-        if gfx and name:
-            break
-    return gfx, name
+            # The agent's own Name is the bare gfx target (e.g. "gfx1151").
+            # ISA sub-blocks report "amdgcn-amd-amdhsa--gfx1151" -- skip those
+            # via the startswith("gfx") guard.
+            if val.startswith("gfx") and not cand_gfx:
+                cand_gfx = val
+        elif s.startswith("Marketing Name:") and not cand_name:
+            cand_name = s.split(":", 1)[1].strip()
+        elif s.startswith("Device Type:") and "GPU" in s and cand_gfx:
+            return cand_gfx, cand_name
+    return "", ""
 
 
 def _gfx_target_from_sysfs() -> tuple[str, str]:


### PR DESCRIPTION
## Problem

`apu-memory-tuner`'s `detect_platform.py` misclassifies a supported AMD APU as "No AMD APU detected" (exit 2) on the exact hardware the skill targets.

Root cause is in `_gfx_target_from_rocminfo()`. It only captures the agent's `Name:` and `Marketing Name:` **after** it has already seen a `Device Type: GPU` line (`in_gpu_agent` gate). But `rocminfo` prints those two lines **before** `Device Type:` inside each agent block, so the gate is never satisfied for the lines that matter and the function returns `("", "")`. Detection then falls through to `is_apu = False`.

### Reproduction (Ryzen AI MAX+ 395 / Strix Halo, gfx1151 — RDNA3.5)

`rocminfo` field order within the GPU agent block:

```
Agent 2
  Name:                    gfx1151
  Marketing Name:          Radeon 8060S Graphics
  Vendor Name:             AMD
  Device Type:             GPU        <-- comes AFTER Name / Marketing Name
```

Before this change:

```
GFX target:        unknown
Generation:        unknown
APU:               False
Supported by skill: NO
  - No AMD APU detected. ...
# exit 2
```

## Fix

Buffer the current agent block's candidate gfx target + marketing name, and commit them the moment a `Device Type: GPU` line confirms the block is a GPU. Reset the buffer on each `Agent N` header. The `startswith("gfx")` guard still skips the ISA sub-block `Name:` lines (`amdgcn-amd-amdhsa--gfx1151`).

After:

```
GPU:               Radeon 8060S Graphics
GFX target:        gfx1151
Generation:        rdna35
APU:               True
Supported by skill: YES
# exit 0
```

No behavior change on hardware that already detected correctly (the sysfs fallback and all other fields are untouched); this only fixes the rocminfo path that was silently returning empty.
