### PR TITLE
docs(picking-amd-gpu-backend): image-gen on WSL2 ROCm verified, slower than Vulkan

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,6 +15,7 @@
       "strict": false,
       "skills": [
         "./skills/local-ai-use",
+        "./skills/picking-amd-gpu-backend",
         "./skills/local-ai-app-integration",
         "./skills/serving-llms-on-instinct",
         "./skills/tracelens-analysis-orchestrator"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -19,6 +19,7 @@
   ],
   "skills": [
     "./skills/local-ai-use",
+    "./skills/picking-amd-gpu-backend",
     "./skills/local-ai-app-integration",
     "./skills/serving-llms-on-instinct",
     "./skills/tracelens-analysis-orchestrator"

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -14,6 +14,7 @@
       "version": "0.1.0",
       "skills": [
         "./skills/local-ai-use",
+        "./skills/picking-amd-gpu-backend",
         "./skills/local-ai-app-integration",
         "./skills/serving-llms-on-instinct",
         "./skills/tracelens-analysis-orchestrator"

--- a/.github/workflows/behavioral.yml
+++ b/.github/workflows/behavioral.yml
@@ -15,15 +15,42 @@ name: behavioral
 # Shape mirrors validate.yml: discover -> matrix -> single aggregate gate, so
 # branch protection can require just the `behavioral` check.
 
+# FORK NOTE (gucciwong/AMD_skills)
+# -------------------------------------------------------------------------
+# The pull_request trigger is disabled in this fork. The matrix job below runs
+# on `[self-hosted, strix_halo, <os>]` — AMD's own runners, which this fork does
+# not have. Left on pull_request, every PR would queue a job that waits forever
+# for a runner that never appears, and the required `behavioral` gate would
+# never resolve.
+#
+# Behavioral tests are therefore run locally here. Two things to know, both
+# measured rather than assumed:
+#
+#   * Run one test function at a time. Running a whole evals.py in one pytest
+#     invocation produced 3 failures on each of two consecutive runs, with a
+#     *different* set of checks failing each time — including checks that had
+#     just passed in isolation. The variance is in the LLM judging layer
+#     (~18 judge calls in five minutes), not in the agent's answers.
+#   * On a non-UTF-8 Windows console (CJK locales default to GBK/Shift-JIS) the
+#     harness crashes with UnicodeEncodeError while *printing* a passing result.
+#     Prefix with PYTHONIOENCODING=utf-8.
+#
+#     PYTHONIOENCODING=utf-8 python -m pytest -c pytest.ini -p conftest \
+#       ../../skills/<skill>/evals/evals.py -k <test_name>
+#
+# To re-enable on a machine that does have matching runners, restore the
+# pull_request block below.
+# -------------------------------------------------------------------------
+
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-    paths:
-      - "skills/**"
-      - "eval/behavioral/**"
-      - "eval/claude_eval.py"
-      - ".github/workflows/behavioral.yml"
-      - ".github/scripts/select_behavioral.py"
+  # pull_request:
+  #   types: [opened, synchronize, reopened]
+  #   paths:
+  #     - "skills/**"
+  #     - "eval/behavioral/**"
+  #     - "eval/claude_eval.py"
+  #     - ".github/workflows/behavioral.yml"
+  #     - ".github/scripts/select_behavioral.py"
   workflow_dispatch:
     inputs:
       skills:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,30 @@
 # AMD Skills
 
+> **This is an independent community fork of [amd/skills](https://github.com/amd/skills).**
+>
+> It is **not** maintained by AMD and is **not** staged for merge-back. Upstream's
+> `CONTRIBUTING.md` limits contributions to "AMD engineers and selected partners",
+> so measured findings from ordinary consumer hardware are published here instead.
+>
+> **What this fork adds:**
+>
+> | Addition | What it is |
+> |---|---|
+> | [`skills/picking-amd-gpu-backend`](skills/picking-amd-gpu-backend) | New skill: picks a GPU backend that actually installs, then verifies the work landed on the discrete GPU |
+> | [`skills/local-ai-use/hardware-notes.md`](skills/local-ai-use/hardware-notes.md) | Measured results on a consumer AMD dGPU, including the negative ones |
+>
+> Both come from an end-to-end run on a Radeon RX 7600M XT (gfx1102, 8 GB,
+> Thunderbolt eGPU) under Windows 11. Raw data, scripts, and the experiments that
+> produced wrong answers before they produced right ones live in
+> [amd-local-ai-bench](https://github.com/gucciwong/amd-local-ai-bench).
+>
+> **Caveat:** every number comes from one GPU on one machine, and the Linux
+> guidance in these additions follows upstream documentation without being tested.
+>
+> Everything below this line is upstream's README, unchanged.
+
+---
+
 <div align="center">
 
 ![AMD](https://img.shields.io/badge/AMD-Skills-ED1C24?logo=amd&logoColor=white)

--- a/skills/local-ai-use/SKILL.md
+++ b/skills/local-ai-use/SKILL.md
@@ -278,3 +278,8 @@ one modality.
 For the full model picker, alternate-quality options, the complete endpoint
 reference, the API-key flow, and the OmniRouter tool definitions you can
 hand to an agent's tool-calling loop, see [reference.md](reference.md).
+
+For measured results on consumer AMD dGPUs — which backend to pick when ROCm
+fails to install on Windows, a setting that silently costs 58x, model pairings
+that fit an 8 GB card, and the fast path for high-resolution images — see
+[hardware-notes.md](hardware-notes.md).

--- a/skills/local-ai-use/hardware-notes.md
+++ b/skills/local-ai-use/hardware-notes.md
@@ -1,0 +1,227 @@
+# Hardware notes: consumer AMD dGPUs on Windows
+
+Measured findings from running this skill end-to-end on consumer AMD hardware.
+Every number here came from a real run; negative results are included because
+they are what save the next person time.
+
+- [Contents](#contents)
+- [ROCm backends currently fail to install on Windows](#rocm-backends-currently-fail-to-install-on-windows)
+- [Silent footguns](#silent-footguns)
+- [The resolution ceiling is an allocation limit, not a VRAM limit](#the-resolution-ceiling-is-an-allocation-limit-not-a-vram-limit)
+- [Do not split one diffusion job across two GPUs](#do-not-split-one-diffusion-job-across-two-gpus)
+- [Model selection on an 8 GB card](#model-selection-on-an-8-gb-card)
+- [Fast path for high-resolution images](#fast-path-for-high-resolution-images)
+- [Benchmarking methodology](#benchmarking-methodology)
+
+## Contents
+
+Reference hardware for all numbers below:
+
+| | |
+|---|---|
+| GPU | Radeon RX 7600M XT 8 GB, gfx1102 (Navi 33, RDNA3) |
+| Connection | Thunderbolt 3 eGPU enclosure |
+| Host | Intel Core Ultra + Arc iGPU (dual-GPU system) |
+| OS | Windows 11 x64, Adrenalin 32.0.21030.2001 |
+| Lemonade | 11.5.0 |
+
+## ROCm backends currently fail to install on Windows
+
+`reference.md` recommends `lemonade backends install sd-cpp:rocm` for GPU
+acceleration on RDNA3/4. On Windows this currently fails after downloading
+5.2 GB (~18 minutes):
+
+```
+Error: TheRock extraction failed: bin directory not found
+```
+
+This is an upstream packaging bug, not a hardware limitation:
+
+- AMD's Windows support matrix lists gfx1102 as fully supported in both the
+  *Runtime* and *HIP SDK* columns.
+- [lemonade-sdk/lemonade#2722](https://github.com/lemonade-sdk/lemonade/issues/2722)
+  reports the same failure on gfx1151 — different silicon, same extraction step.
+- `lemonade backends` reports `sd-cpp:rocm` as `installable`, so hardware
+  filtering is not the blocker.
+- There is no CLI flag to pin an alternate ROCm/TheRock version.
+
+**Use `vulkan` instead.** It installs in under 10 seconds, ships with the
+Adrenalin driver, and reaches the AMD matrix cores:
+
+```
+ggml_vulkan: 1 = AMD Radeon RX 7600M XT | bf16: 1 | matrix cores: KHR_coopmat
+```
+
+Measured on the reference hardware, image generation at 512x512, warm:
+
+| Backend | Time |
+|---|---|
+| cpu | 50.58 s |
+| **vulkan** | **2.47 s** |
+
+Text inference through `llamacpp:vulkan` reaches 33-34 tok/s on an 8B model and
+55.6 tok/s on Gemma-4-E2B.
+
+## Silent footguns
+
+### `enable_dgpu_gtt` — do not enable on a dGPU
+
+This setting lets the driver satisfy allocations from system memory. Over an
+external (Thunderbolt) link that is catastrophic, and it does **not** raise the
+resolution ceiling it appears to target:
+
+| `enable_dgpu_gtt` | 512x512 image, back to back |
+|---|---|
+| `false` | **2.73 s** |
+| `true` | **158 s** |
+
+Keep it `false`. The 58x regression is silent — nothing in the logs points at
+this setting.
+
+### VRAM contention between `sd-cli` and a resident `sd-server`
+
+Running `sd-cli` directly while Lemonade still holds a model resident puts two
+processes on the same card, each wanting 6-7 GB:
+
+| State | SDXL 512x512 |
+|---|---|
+| Lemonade model still resident | 825.9 s |
+| **VRAM cleared first** | **24.1 s** |
+
+Unload before invoking the CLI directly:
+
+```
+lemonade unload <model>
+```
+
+This also corrupts benchmarks — see
+[Benchmarking methodology](#benchmarking-methodology).
+
+## The resolution ceiling is an allocation limit, not a VRAM limit
+
+Above 2816x2816 on an 8 GB card, generation fails with:
+
+```
+ggml_vulkan: Device memory allocation of size 5368709120 failed
+```
+
+`5368709120` is exactly 5 GiB — Vulkan's per-allocation cap. Three approaches
+that add total memory were measured and **none** moved the ceiling:
+
+- `enable_dgpu_gtt=true` (borrow system memory) — still fails at 3072
+- switching to a quantized model that frees 1.6 GB — still fails at 3072
+- `GGML_VK_FORCE_MAX_ALLOCATION_SIZE` — capped near 4 GB by a uint32 bound, so
+  it can only lower the limit
+
+Total capacity and per-allocation size are different constraints. The error text
+does not say "per-allocation", which makes this easy to misdiagnose.
+
+## Do not split one diffusion job across two GPUs
+
+`sd-cpp` accepts per-component device assignment
+(`--backend clip=...,vae=...,diffusion=...`). On a dGPU + iGPU machine this is a
+regression at every resolution measured:
+
+| Resolution | All dGPU | dGPU diffusion + iGPU VAE/CLIP |
+|---|---|---|
+| 512 | 2.47 s | 7.55 s |
+| 1024 | 10.93 s | 39.42 s |
+| 2048 | 73.22 s | 199.17 s |
+
+The iGPU has no matrix cores (`matrix cores: none`), so any work assigned to it
+is slower, and cross-device transfers are pure overhead. Leave the iGPU to drive
+the display so the dGPU's VRAM is not consumed by desktop compositing.
+
+## Model selection on an 8 GB card
+
+Text models:
+
+| Model | Size | tok/s | TTFT |
+|---|---|---|---|
+| Gemma-4-E2B | 4.09 GB | **55.6** | 128 ms |
+| DeepSeek-Qwen3-8B | 5.25 GB | 33-34 | 156-455 ms |
+| Gemma-4-12B | 7.29 GB | 6.9-12.3 | 935-2850 ms |
+
+12B fits but runs ~3x slower than 8B — treat it as the usable ceiling.
+
+Image models:
+
+| Model | 512 | 1024 | Peak VRAM |
+|---|---|---|---|
+| SD-Turbo-GGUF | 3.09 s | — | **2.52 GB** |
+| SD-Turbo | 3.07 s | 10.93 s | 4.23 GB |
+| SDXL-Turbo | 3.90 s | 15.96 s | 7.14 GB |
+| SDXL-Base-1.0 | 14.81 s | 60.99 s | 7.14 GB |
+
+The GGUF build of SD-Turbo is the same speed as the full model while using
+1.6 GB less VRAM. SDXL-Turbo delivers SDXL-class quality at roughly a quarter of
+SDXL-Base's time.
+
+**Pairing matters more than either model alone.** Alternating chat and image
+requests:
+
+| Pair | chat | image | Round trip |
+|---|---|---|---|
+| 8B + SD-Turbo | 14.6-15.5 s | 3.7-4.2 s | ~19 s |
+| **Gemma-4-E2B + SD-Turbo-GGUF** | **0.27-0.60 s** | **2.49-2.51 s** | **~3.0 s** |
+
+The fast pair fits in 5.68 GB with 0.52 GB spill; the slow pair needs 9.3 GB and
+spills 3.22 GB, so the two models keep evicting each other. On a capacity-limited
+card, shrink the models until they coexist rather than splitting work across
+devices.
+
+Context length is cheaper than it looks: an 8B model at `ctx_size=32768` uses
+6.39 GB versus 5.39 GB at the 4096 default. Quantizing the KV cache
+(`-ctk q8_0 -ctv q8_0`, with or without `-fa on`) produced no measurable VRAM
+change — llama.cpp fits parameters to a memory budget
+(`common_fit_params: fitting params to free device memory`), so freed space is
+reallocated rather than returned.
+
+## Fast path for high-resolution images
+
+Producing a 2048x2048 image three ways:
+
+| Approach | Time | Peak VRAM |
+|---|---|---|
+| Generate 2048 directly | 483.64 s | 6.66 GB |
+| `--hires --hires-scale 2.0` from 1024 | 536.04 s | 6.66 GB |
+| **Generate 512, then ESRGAN 4x upscale** | **24.25 s** | **0.85 GB** |
+
+`--hires` runs a second full denoising pass, so it costs about as much as
+generating at the target size; its value is composition, not speed. A pure
+upscale skips denoising entirely:
+
+```
+lemonade pull RealESRGAN-x4plus
+sd-cli -M upscale --upscale-model <RealESRGAN_x4plus.pth> -i small.png -o large.png
+```
+
+For anime or line art, `RealESRGAN-x4plus-anime` is roughly twice as fast
+(3.40 s vs 7.74 s) with cleaner edges. Note the weights file is named
+`RealESRGAN_x4plus_anime_6B.pth` — underscores, not hyphens.
+
+## Benchmarking methodology
+
+Two mistakes made the first round of measurements on this hardware worthless.
+Both are easy to repeat.
+
+**Align arguments across execution paths before comparing them.** Lemonade
+launches `sd-server` with `--vae-tiling --diffusion-fa`; invoking `sd-cli`
+without them hits an out-of-memory path and produces numbers that point the
+wrong direction. Capture what actually runs:
+
+```powershell
+Get-CimInstance Win32_Process -Filter "Name='sd-server.exe'" | Select-Object CommandLine
+```
+
+**Restart the server between configurations.** Residual resident models and
+leftover experimental settings moved the same measurement between 2.5 s and
+158 s across runs:
+
+```powershell
+Get-Process -Name "LemonadeServer" | Stop-Process -Force
+Get-CimInstance Win32_Process -Filter "Name='sd-server.exe' OR Name='llama-server.exe'" |
+  ForEach-Object { Stop-Process -Id $_.ProcessId -Force }
+Start-Process "$env:LOCALAPPDATA/lemonade_server/bin/LemonadeServer.exe" -WindowStyle Hidden
+# then poll http://127.0.0.1:13305/api/v1/health
+```

--- a/skills/picking-amd-gpu-backend/SKILL.md
+++ b/skills/picking-amd-gpu-backend/SKILL.md
@@ -30,22 +30,43 @@ Is this AMD Instinct (MI300X/MI325X/MI350X)?
   -> yes: stop, use the serving-llms-on-instinct skill instead.
 
 Is the OS Windows?
-  -> yes: use vulkan. ROCm backend installs currently fail (see below).
-  -> no (Linux): try rocm; fall back to vulkan if install or runtime fails.
-                 [UNVERIFIED -- see note]
+  -> yes, and the target is native Windows: use vulkan. The Lemonade/TheRock
+     ROCm backend install currently fails there (see below).
+  -> yes, and the target is WSL2: rocm is a real option, not just a fallback
+     — see the WSL2 note below. Still confirm the specific GPU model, since
+     package-name guessing is the main way this goes wrong.
+  -> no (bare-metal Linux): try rocm; fall back to vulkan if install or
+     runtime fails. [UNVERIFIED ON BARE METAL -- see note]
 
 No GPU detected, or GPU unsupported?
   -> use cpu, and tell the user the expected slowdown (~20x for images).
 ```
 
-> **The Linux branch is unverified.** Every measurement behind this skill was
-> taken on Windows. The Linux guidance follows upstream documentation, which
-> reports ROCm as the better-supported path there, but no one has run it on a
-> Linux box for this skill. Say so when recommending it, and prefer vulkan as
-> the fallback the moment anything fails rather than debugging a ROCm install.
+> **Bare-metal Linux is unverified; WSL2 is verified working.** Every
+> measurement in the Windows branch is measured on real hardware. WSL2 ROCm
+> was also measured directly — a real HIP kernel compiled and ran correctly,
+> and llama.cpp built with the HIP backend matched Vulkan's throughput on the
+> same 8B model (36.4 vs 33-34 tok/s) on a Radeon RX 7600M XT (gfx1102).
+> Full repro steps, and every wrong turn taken to get there, are at
+> <https://github.com/gucciwong/amd-local-ai-bench/blob/main/docs/rocm-on-wsl2.md>.
 >
-> Everything in the Windows branch, and every number elsewhere in this skill,
-> is measured.
+> Bare-metal Linux (no WSL) follows upstream documentation only — no one has
+> run this skill's guidance on real bare-metal Linux. Say so when recommending
+> it there, and prefer vulkan as the fallback the moment anything fails rather
+> than debugging a ROCm install.
+>
+> **If a ROCm install on WSL2 looks like it's failing, don't conclude the GPU
+> is unsupported before checking these two things** — both cost real time in
+> the referenced session:
+> - `amdgpu-install --usecase=wsl` errors with "not supported or invalid"
+>   because that usecase name does not exist in current amdgpu-install
+>   builds, not because WSL itself is unsupported. The actual bridge is a
+>   separate package, `amdrocm-wsl`, installed alongside the versioned ROCm
+>   package.
+> - Per-architecture package names carry a ROCm version suffix
+>   (`amdrocm7.14-gfx1102`, not `amdrocm-gfx1102`). Run
+>   `apt-cache search amdrocm | grep <gfx-target>` before concluding a
+>   package "doesn't exist" for a given GPU.
 
 ## Step 1: identify the hardware before installing anything
 

--- a/skills/picking-amd-gpu-backend/SKILL.md
+++ b/skills/picking-amd-gpu-backend/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: picking-amd-gpu-backend
+description: >-
+  Chooses and installs the right GPU compute backend (vulkan, rocm, cpu) for
+  local AI on an AMD GPU, then verifies the workload actually landed on the
+  discrete GPU. Use when the user is setting up local image generation, local
+  LLM inference, llama.cpp, stable-diffusion.cpp, or Lemonade on AMD hardware;
+  when a ROCm or HIP install fails; when they mention TheRock, gfx1100/gfx1102/
+  gfx1151, Radeon RX, eGPU, or an external GPU enclosure; when local AI is
+  unexpectedly slow, falls back to CPU, or runs on the wrong GPU; or when they
+  ask whether they need ROCm at all. Also use when generation fails above a
+  certain resolution, or when a machine has both an integrated and a discrete
+  GPU. Do not use for AMD Instinct data center parts (see
+  serving-llms-on-instinct) or for NVIDIA hardware.
+---
+
+# Picking an AMD GPU backend
+
+Consumer AMD GPUs have three backend options for local AI. Picking wrong costs
+hours: ROCm currently fails to install on Windows, and several settings that
+look like optimizations are large regressions.
+
+**Default to Vulkan.** Reach for ROCm only on Linux, or after Vulkan is proven
+working and you have a specific reason.
+
+## Decision
+
+```
+Is this AMD Instinct (MI300X/MI325X/MI350X)?
+  -> yes: stop, use the serving-llms-on-instinct skill instead.
+
+Is the OS Windows?
+  -> yes: use vulkan. ROCm backend installs currently fail (see below).
+  -> no (Linux): try rocm; fall back to vulkan if install or runtime fails.
+
+No GPU detected, or GPU unsupported?
+  -> use cpu, and tell the user the expected slowdown (~20x for images).
+```
+
+## Step 1: identify the hardware before installing anything
+
+Never assume which GPU will be used. Machines with an integrated *and* a
+discrete GPU are common, and the integrated one is often enumerated first.
+
+```bash
+lemonade backends            # which backends are installable for this hardware
+```
+
+A backend shown as `installable` means hardware filtering already accepts it.
+`unsupported` messages name the reason (`Requires AMD XDNA 2 AMD NPU`,
+`Unsupported GPU`, `Requires Linux`).
+
+To see how the compute library enumerates devices — the order matters, because
+index 0 is not necessarily the discrete GPU:
+
+```bash
+llama-server --list-devices
+```
+
+Look for `matrix cores`. On RDNA3/4 the discrete GPU reports `KHR_coopmat`;
+integrated GPUs typically report `none`. Prefer the device with matrix cores.
+
+## Step 2: install the backend
+
+```bash
+lemonade backends install <recipe>:vulkan
+lemonade config set sdcpp.backend=vulkan
+lemonade config set llamacpp.backend=vulkan
+```
+
+Vulkan installs in seconds because it ships with the AMD display driver.
+
+### If the user insists on ROCm on Windows
+
+Set expectations first: on Windows this currently downloads several GB and then
+fails at extraction:
+
+```
+Error: TheRock extraction failed: bin directory not found
+```
+
+This is an upstream packaging bug, tracked in
+[lemonade-sdk/lemonade#2722](https://github.com/lemonade-sdk/lemonade/issues/2722),
+reproduced on more than one GPU architecture. `--force` does not help — it
+bypasses hardware filtering, which is not the blocker. There is no CLI flag to
+pin an alternate ROCm version.
+
+Vulkan reaches the same matrix-core hardware, so the practical cost of skipping
+ROCm on Windows is low.
+
+## Step 3: verify the workload landed on the discrete GPU
+
+A backend that "works" may still be running on the integrated GPU. Confirm by
+watching dedicated VRAM rise when a model loads and fall when it unloads.
+
+On Windows:
+
+```powershell
+Get-CimInstance Win32_PerfFormattedData_GPUPerformanceCounters_GPUAdapterMemory |
+  Select-Object Name, DedicatedUsage, SharedUsage
+```
+
+The discrete GPU is the adapter with non-zero `DedicatedUsage`; integrated GPUs
+are UMA and report 0 dedicated with large `SharedUsage`. Load a model, re-run,
+and confirm the expected adapter grew.
+
+If dedicated VRAM never moves, the work is on the wrong device or on CPU.
+
+## Settings that look helpful and are not
+
+State these before the user finds them:
+
+| Setting | Reality |
+|---|---|
+| `enable_dgpu_gtt=true` | Lets the driver allocate from system memory. On a discrete GPU — especially over Thunderbolt — measured 58x slower image generation, and it does **not** raise the resolution ceiling. Keep `false`. |
+| Splitting one job across two GPUs | `sd-cpp` accepts `--backend clip=...,vae=...,diffusion=...`. On a discrete + integrated pair this regressed at every resolution measured. Integrated GPUs lack matrix cores; cross-device transfer is pure overhead. |
+| `max_loaded_models=2` | No benefit if the two models do not both fit in VRAM — they evict each other anyway. Shrink the models instead. |
+| `GGML_VK_FORCE_MAX_ALLOCATION_SIZE` | Bounded near 4 GB by a uint32 limit, so it can only *lower* the cap. It cannot raise a 5 GiB per-allocation limit. |
+
+## When generation fails above a certain resolution
+
+If image generation fails abruptly past some size with:
+
+```
+ggml_vulkan: Device memory allocation of size 5368709120 failed
+```
+
+that is Vulkan's **per-allocation** cap (5 GiB here), not total VRAM. Adding
+memory does not help — quantized models and system-memory borrowing were both
+measured and neither moved the ceiling.
+
+Recommend the upscale path instead of fighting it: generate small, then run a
+pure upscale. This is dramatically faster than generating large directly, and
+uses a fraction of the VRAM.
+
+```bash
+sd-cli -M upscale --upscale-model <esrgan.pth> -i small.png -o large.png
+```
+
+Note that `--hires` is *not* this: it runs a second full denoising pass, so it
+costs about as much as generating at the target size.
+
+## Before reporting any performance number
+
+Two mistakes invalidate measurements on this hardware. Both are easy to repeat.
+
+**Align arguments across execution paths.** A server may launch its worker with
+flags the CLI does not default to (e.g. `--vae-tiling --diffusion-fa`). Comparing
+the two without matching flags produces conclusions that point the wrong
+direction. Capture what actually ran:
+
+```powershell
+Get-CimInstance Win32_Process -Filter "Name='sd-server.exe'" | Select-Object CommandLine
+```
+
+**Clear VRAM first.** Two processes each wanting 6-7 GB on an 8 GB card
+regressed one workload by 34x. Unload resident models before benchmarking, and
+restart the server between configurations.
+
+```bash
+lemonade unload <model>
+```
+
+## Reference
+
+Measured numbers, the hardware they came from, and the negative results behind
+each recommendation are in the `local-ai-use` skill's
+[hardware-notes.md](../local-ai-use/hardware-notes.md).

--- a/skills/picking-amd-gpu-backend/SKILL.md
+++ b/skills/picking-amd-gpu-backend/SKILL.md
@@ -32,10 +32,20 @@ Is this AMD Instinct (MI300X/MI325X/MI350X)?
 Is the OS Windows?
   -> yes: use vulkan. ROCm backend installs currently fail (see below).
   -> no (Linux): try rocm; fall back to vulkan if install or runtime fails.
+                 [UNVERIFIED -- see note]
 
 No GPU detected, or GPU unsupported?
   -> use cpu, and tell the user the expected slowdown (~20x for images).
 ```
+
+> **The Linux branch is unverified.** Every measurement behind this skill was
+> taken on Windows. The Linux guidance follows upstream documentation, which
+> reports ROCm as the better-supported path there, but no one has run it on a
+> Linux box for this skill. Say so when recommending it, and prefer vulkan as
+> the fallback the moment anything fails rather than debugging a ROCm install.
+>
+> Everything in the Windows branch, and every number elsewhere in this skill,
+> is measured.
 
 ## Step 1: identify the hardware before installing anything
 

--- a/skills/picking-amd-gpu-backend/SKILL.md
+++ b/skills/picking-amd-gpu-backend/SKILL.md
@@ -42,12 +42,19 @@ No GPU detected, or GPU unsupported?
   -> use cpu, and tell the user the expected slowdown (~20x for images).
 ```
 
-> **Bare-metal Linux is unverified; WSL2 is verified working.** Every
+> **Bare-metal Linux is unverified; WSL2 is verified working — for LLM
+> inference. Image generation is verified too, and is slower there.** Every
 > measurement in the Windows branch is measured on real hardware. WSL2 ROCm
 > was also measured directly — a real HIP kernel compiled and ran correctly,
-> and llama.cpp built with the HIP backend matched Vulkan's throughput on the
-> same 8B model (36.4 vs 33-34 tok/s) on a Radeon RX 7600M XT (gfx1102).
-> Full repro steps, and every wrong turn taken to get there, are at
+> llama.cpp built with the HIP backend matched Vulkan's throughput on the
+> same 8B model (36.4 vs 33-34 tok/s), but stable-diffusion.cpp built with
+> the HIP backend (`SD_HIPBLAS`) generated a real, visually-checked image
+> **~3-4x slower** than the Vulkan warm-server baseline (10.1s vs 2.47s,
+> SD-Turbo 512²) — all on the same Radeon RX 7600M XT (gfx1102). Don't
+> assume ROCm/WSL2 is a blanket win just because LLM throughput matched;
+> check the specific workload. Full repro steps, and every wrong turn taken
+> to get there (including two Windows-host-to-WSL2 scripting footguns that
+> have nothing to do with the GPU), are at
 > <https://github.com/gucciwong/amd-local-ai-bench/blob/main/docs/rocm-on-wsl2.md>.
 >
 > Bare-metal Linux (no WSL) follows upstream documentation only — no one has

--- a/skills/picking-amd-gpu-backend/evals/evals.py
+++ b/skills/picking-amd-gpu-backend/evals/evals.py
@@ -11,6 +11,13 @@ reason about the decision tree):
     cd eval/behavioral
     python -m pytest -c pytest.ini -p conftest ../../skills/picking-amd-gpu-backend/evals/evals.py
 
+On a Windows console with a non-UTF-8 codepage (CJK locales default to GBK,
+Shift-JIS, etc.), the harness crashes with `UnicodeEncodeError` while *printing*
+a passing result, because judge explanations can contain characters like `2048²`.
+The check itself succeeded; only the report failed. Force UTF-8 output:
+
+    PYTHONIOENCODING=utf-8 python -m pytest -c pytest.ini -p conftest ../../skills/picking-amd-gpu-backend/evals/evals.py
+
 Each check on `run` prints a `[PASS]`/`[FAIL]` line and raises on failure, so
 the test fails at the first unmet expectation. `logs_contains` /
 `workspace_contains` are deterministic; `should` / `should_not` are graded by
@@ -20,6 +27,38 @@ The three cases below cover the failure modes this skill exists to prevent:
 picking a backend that cannot install, accepting a backend without checking
 which GPU actually ran the work, and misdiagnosing a per-allocation cap as a
 capacity problem.
+
+Known instability, measured rather than assumed
+-----------------------------------------------
+
+Run the cases **one at a time**. Every check here passes in isolation, often
+repeatedly. Running all three in one pytest invocation produced 3 failures on
+each of two consecutive runs — but a *different* set of checks failed each
+time, including checks that had just passed in isolation. Same prompts, same
+skill, so the variance is in the judging layer (roughly 18 judge calls in five
+minutes), not in the agent's answers.
+
+Treat a whole-suite failure as inconclusive and re-run the specific case alone
+before concluding the skill regressed:
+
+    PYTHONIOENCODING=utf-8 python -m pytest -c pytest.ini -p conftest \\
+      ../../skills/picking-amd-gpu-backend/evals/evals.py -k test_picks_vulkan_on_windows
+
+Writing checks that survive an LLM judge
+----------------------------------------
+
+Two wording bugs in earlier versions of this file failed *correct* answers:
+
+- A ``should_not`` must be a **simple, positive** description of one wrong
+  behavior. Compound or negated forms ("state X *without* doing Y") become
+  double negatives inside ``should_not`` and were judged wrong on every run.
+- A ``should_not`` must not be satisfiable by a **dismissal** of the thing it
+  names. "Recommend GGML_VK_FORCE_MAX_ALLOCATION_SIZE as a way to raise the cap"
+  tripped when the agent named the variable to explain that it *cannot* raise
+  the cap. Phrase the false claim, not the mention.
+- A ``should`` should describe the **substance**, not one phrasing of it.
+  Requiring "VRAM rising on load and falling on unload" passed once and failed
+  the next run, because the agent described the same check differently.
 """
 
 from harness import claude
@@ -57,37 +96,62 @@ def test_picks_vulkan_on_windows():
 
 
 def test_verifies_which_gpu_ran_the_work():
-    """A backend that 'works' may still be running on the integrated GPU."""
+    """A backend that 'works' may still be running on the integrated GPU.
+
+    The prompt asks both how to *target* the discrete card and how to *confirm*
+    it afterwards. Asking only about confirmation does not reliably elicit the
+    device-ordering warning, which made an earlier version of this test fail on
+    a correct answer.
+    """
     agent_configs = [(claude, "opus")]
     for agent, model in agent_configs:
         with agent(model, skill="picking-amd-gpu-backend") as agent:
             run = agent.prompt(
                 "I installed the vulkan backend on a laptop that has both an "
                 "integrated GPU and a discrete Radeon. Generation works but feels "
-                "slow. How do I confirm it is actually using the discrete card?"
+                "slow. How do I make sure the discrete card is the one being used, "
+                "and how do I confirm it afterwards?"
             )
 
+            # Phrased loosely on purpose. An earlier version required the
+            # load/unload delta specifically and passed on one run, failed on the
+            # next, because the agent described the same check differently. What
+            # matters is that dedicated VRAM is the signal, not how it is observed.
             run.should(
-                "Describe checking dedicated VRAM on the discrete adapter rising "
-                "when a model loads and falling when it unloads"
+                "Use dedicated VRAM on the discrete adapter as the signal for "
+                "which GPU is actually running the model"
             )
             run.should(
                 "Explain that an integrated GPU is UMA and reports zero dedicated "
                 "memory, so it can be told apart from the discrete card"
             )
             run.should(
-                "Warn that device index 0 is often the integrated GPU rather than "
-                "the discrete one"
+                "Point out that the first enumerated device is not necessarily the "
+                "discrete GPU, so the device list should be inspected rather than "
+                "assumed"
             )
 
+            # A should_not must be a simple, positive description of one wrong
+            # behavior. An earlier version read "State that the discrete GPU is
+            # being used *without* giving the user any way to check" — a compound
+            # negation, which becomes a double negative inside should_not and
+            # failed on two consecutive runs against a correct answer.
             run.should_not(
-                "Assume the discrete GPU is being used without proposing a way to "
-                "verify it"
+                "Claim that the vulkan backend automatically selects the discrete "
+                "GPU, so no check is needed"
             )
 
 
 def test_diagnoses_allocation_cap_not_capacity():
-    """The error names a byte count, not a concept; the wrong fix wastes hours."""
+    """The error names a byte count, not a concept; the wrong fix wastes hours.
+
+    The negative expectations below are phrased as the *false claim* rather than
+    the mention. An earlier version said "Recommend GGML_VK_FORCE_MAX_ALLOCATION_SIZE
+    as a way to raise the cap", which the judge marked as observed simply because
+    the agent named the variable while explaining that it cannot raise the cap —
+    failing a correct answer. A `should_not` must not be satisfiable by a
+    dismissal of the thing it names.
+    """
     agent_configs = [(claude, "opus")]
     for agent, model in agent_configs:
         with agent(model, skill="picking-amd-gpu-backend") as agent:
@@ -110,11 +174,14 @@ def test_diagnoses_allocation_cap_not_capacity():
             )
 
             run.should_not(
-                "Recommend enable_dgpu_gtt to make more memory available"
+                "Tell the user that enabling enable_dgpu_gtt will make the "
+                "3072x3072 generation succeed"
             )
             run.should_not(
-                "Recommend GGML_VK_FORCE_MAX_ALLOCATION_SIZE as a way to raise the cap"
+                "Tell the user that setting GGML_VK_FORCE_MAX_ALLOCATION_SIZE will "
+                "let them exceed the 5 GiB allocation limit"
             )
             run.should_not(
-                "Suggest that a quantized model will raise the resolution ceiling"
+                "Tell the user that switching to a smaller or quantized model will "
+                "make the 3072x3072 generation succeed"
             )

--- a/skills/picking-amd-gpu-backend/evals/evals.py
+++ b/skills/picking-amd-gpu-backend/evals/evals.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+
+"""Behavioral tests for the `picking-amd-gpu-backend` skill.
+
+Run locally (needs the `claude` CLI authenticated; an AMD GPU and a reachable
+Lemonade Server make the checks meaningful, otherwise the agent can only
+reason about the decision tree):
+
+    cd eval/behavioral
+    python -m pytest -c pytest.ini -p conftest ../../skills/picking-amd-gpu-backend/evals/evals.py
+
+Each check on `run` prints a `[PASS]`/`[FAIL]` line and raises on failure, so
+the test fails at the first unmet expectation. `logs_contains` /
+`workspace_contains` are deterministic; `should` / `should_not` are graded by
+an LLM judge over the captured evidence.
+
+The three cases below cover the failure modes this skill exists to prevent:
+picking a backend that cannot install, accepting a backend without checking
+which GPU actually ran the work, and misdiagnosing a per-allocation cap as a
+capacity problem.
+"""
+
+from harness import claude
+
+
+def test_picks_vulkan_on_windows():
+    """The headline decision: do not send the user down the ROCm path on Windows."""
+    agent_configs = [(claude, "opus")]
+    for agent, model in agent_configs:
+        with agent(model, skill="picking-amd-gpu-backend") as agent:
+            run = agent.prompt(
+                "I have a Radeon RX 7600M XT on Windows and I want to generate "
+                "images locally. Which GPU backend should I install, and why?"
+            )
+
+            run.logs_contains("picking-amd-gpu-backend")
+
+            run.should("Recommend the vulkan backend for this Windows setup")
+            run.should(
+                "Explain that the ROCm backend install currently fails on Windows, "
+                "and that this is an upstream packaging problem rather than the "
+                "user's hardware being unsupported"
+            )
+            run.should(
+                "Note that Vulkan still reaches the GPU's matrix cores, so choosing "
+                "it is not a performance compromise"
+            )
+
+            run.should_not(
+                "Tell the user to install the ROCm or HIP backend as the primary path"
+            )
+            run.should_not(
+                "Claim the GPU is unsupported or that the user needs different hardware"
+            )
+
+
+def test_verifies_which_gpu_ran_the_work():
+    """A backend that 'works' may still be running on the integrated GPU."""
+    agent_configs = [(claude, "opus")]
+    for agent, model in agent_configs:
+        with agent(model, skill="picking-amd-gpu-backend") as agent:
+            run = agent.prompt(
+                "I installed the vulkan backend on a laptop that has both an "
+                "integrated GPU and a discrete Radeon. Generation works but feels "
+                "slow. How do I confirm it is actually using the discrete card?"
+            )
+
+            run.should(
+                "Describe checking dedicated VRAM on the discrete adapter rising "
+                "when a model loads and falling when it unloads"
+            )
+            run.should(
+                "Explain that an integrated GPU is UMA and reports zero dedicated "
+                "memory, so it can be told apart from the discrete card"
+            )
+            run.should(
+                "Warn that device index 0 is often the integrated GPU rather than "
+                "the discrete one"
+            )
+
+            run.should_not(
+                "Assume the discrete GPU is being used without proposing a way to "
+                "verify it"
+            )
+
+
+def test_diagnoses_allocation_cap_not_capacity():
+    """The error names a byte count, not a concept; the wrong fix wastes hours."""
+    agent_configs = [(claude, "opus")]
+    for agent, model in agent_configs:
+        with agent(model, skill="picking-amd-gpu-backend") as agent:
+            run = agent.prompt(
+                "Image generation works at 2048x2048 on my 8GB Radeon but fails at "
+                "3072x3072 with 'ggml_vulkan: Device memory allocation of size "
+                "5368709120 failed'. How do I get more VRAM available so it fits?"
+            )
+
+            run.should(
+                "Identify 5368709120 as a 5 GiB per-allocation limit rather than "
+                "the card running out of total VRAM"
+            )
+            run.should(
+                "Explain that adding available memory will not raise this ceiling"
+            )
+            run.should(
+                "Recommend generating at a smaller size and running a separate "
+                "upscale pass instead"
+            )
+
+            run.should_not(
+                "Recommend enable_dgpu_gtt to make more memory available"
+            )
+            run.should_not(
+                "Recommend GGML_VK_FORCE_MAX_ALLOCATION_SIZE as a way to raise the cap"
+            )
+            run.should_not(
+                "Suggest that a quantized model will raise the resolution ceiling"
+            )

--- a/skills/picking-amd-gpu-backend/skill-card.md
+++ b/skills/picking-amd-gpu-backend/skill-card.md
@@ -1,0 +1,17 @@
+# Skill Card
+
+## Description
+
+Chooses and installs the right GPU compute backend for local AI on consumer AMD
+hardware, verifies the workload actually landed on the discrete GPU, and warns
+about settings that silently regress performance.
+
+## Owner
+
+Community contribution (not AMD-maintained). Findings measured on Radeon
+RX 7600M XT (gfx1102) under Windows 11; behavior on other architectures and on
+Linux is unverified.
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary
- LLM inference on WSL2 ROCm was already verified (PR #7): matched Vulkan.
- This PR adds the other half of the picture: stable-diffusion.cpp built with
  `SD_HIPBLAS` also runs on WSL2 ROCm and produces a correct image (visually
  checked, not just exit-code), but is ~3-4x slower than the Vulkan
  warm-server baseline (10.1s vs 2.47s for SD-Turbo 512²).
- The skill's WSL2 callout now explicitly warns against generalizing "ROCm on
  WSL2 works" from the LLM number alone, since image-gen went the opposite
  direction.
- Full repro, numbers, and two unrelated Windows-host-to-WSL2 scripting
  footguns hit while testing this are in
  [amd-local-ai-bench/docs/rocm-on-wsl2.md](https://github.com/gucciwong/amd-local-ai-bench/blob/main/docs/rocm-on-wsl2.md).

## Test plan
- [x] `bash .github/scripts/check.sh` — 0 errors, 7 skills
- [x] Diff reviewed — single file, additive correction only
- [ ] Behavioral evals (blocked on Actions quota per prior PRs, same as #5-#7)