### PR TITLE
Switch TraceLens skill to main branch

### DIFF
--- a/.github/scripts/sources.yml
+++ b/.github/scripts/sources.yml
@@ -40,7 +40,7 @@ sources:
         as: magpie-kernel-evaluator
   - name: amd-agi-tracelens
     repo: AMD-AGI/TraceLens
-    ref: feat/gw_fix_links
+    ref: main
     path: TraceLens/Agent/Analysis/skills
     license: MIT
     skills:

--- a/skills/tracelens-analysis-orchestrator/.federated.json
+++ b/skills/tracelens-analysis-orchestrator/.federated.json
@@ -1,9 +1,9 @@
 {
   "source": "amd-agi-tracelens",
   "repo": "AMD-AGI/TraceLens",
-  "ref": "feat/gw_fix_links",
-  "commit": "9784844c4b9b3f4478c1f81ff49dfea209e309f1",
+  "ref": "main",
+  "commit": "5d2272e342fda97d283bafe4057cc902c5e39358",
   "path": "TraceLens/Agent/Analysis/skills/analysis-orchestrator",
   "license": "MIT",
-  "imported_at": "2026-08-03T20:24:17Z"
+  "imported_at": "2026-08-04T14:53:34Z"
 }


### PR DESCRIPTION
The main branch should be ready to go for nightly updates going forward