### PR TITLE
Create routing test to assess skill precision/recall

### DIFF
--- a/.github/workflows/behavioral.yml
+++ b/.github/workflows/behavioral.yml
@@ -14,11 +14,9 @@ name: behavioral
 #   * opt-in for Instinct -- the MI300X leg is scarce and expensive, so it only
 #     runs on PRs carrying the `enable_mi_ci` label (see behavioral-instinct).
 #
-# This workflow also hosts the *routing* eval (see the `routing` job and
-# eval/routing/): where a behavioral test asks "once this skill runs, does it
-# work?", the routing eval asks "with the whole published catalog installed,
-# does the agent pick the right skill at all?". It is dispatch-only -- pick
-# `routing` from the `mode` dropdown when you run this workflow by hand.
+# The companion question -- "with the whole published catalog installed, does
+# the agent pick the right skill at all?" -- is the routing eval, which lives in
+# its own dispatch-only workflow (routing.yml, eval/routing/).
 #
 # Shape mirrors validate.yml: discover -> matrix -> single aggregate gate, so
 # branch protection can require just the `behavioral` check.
@@ -37,17 +35,8 @@ on:
       - ".github/scripts/select_behavioral.py"
   workflow_dispatch:
     inputs:
-      mode:
-        description: "behavioral = per-skill behavioral tests. routing = the skill-routing eval over eval/routing/prompts.json. both = run each."
-        type: choice
-        required: false
-        default: behavioral
-        options:
-          - behavioral
-          - routing
-          - both
       skills:
-        description: "Comma-separated skill names to test (blank = every skill that has a behavioral test). Ignored when mode is routing."
+        description: "Comma-separated skill names to test (blank = every skill that has a behavioral test)."
         required: false
         default: ""
 
@@ -74,8 +63,6 @@ jobs:
       instinct: ${{ steps.select.outputs.instinct }}
       # ...versus whether they should actually run, which also needs the label.
       instinct_run: ${{ steps.select.outputs.instinct_run }}
-      # Which of the two evals this run is for (see the `mode` dispatch input).
-      run_routing: ${{ steps.select.outputs.run_routing }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -90,18 +77,6 @@ jobs:
         id: select
         run: |
           set -euo pipefail
-          # The routing eval is dispatch-only: it costs tokens on every prompt
-          # and answers a catalog-wide question, so it is never worth running
-          # automatically on a PR that touches one skill.
-          run_behavioral=true
-          run_routing=false
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            case "${{ github.event.inputs.mode }}" in
-              routing) run_behavioral=false; run_routing=true ;;
-              both)    run_routing=true ;;
-            esac
-          fi
-
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             if [ -n "${{ github.event.inputs.skills }}" ]; then
               skills=$(uv run .github/scripts/select_behavioral.py --names "${{ github.event.inputs.skills }}")
@@ -115,13 +90,6 @@ jobs:
               | uv run .github/scripts/select_behavioral.py --changed)
           fi
 
-          # Routing-only run: empty the behavioral matrix. Every downstream
-          # flag is derived from this list, so the strix and Instinct legs skip
-          # and the gate correctly has nothing to enforce for them.
-          if [ "$run_behavioral" != "true" ]; then
-            skills="[]"
-          fi
-          echo "Mode: ${{ github.event.inputs.mode }} (behavioral: $run_behavioral, routing: $run_routing)"
           echo "Selected skills: $skills"
 
           # These skills exercise AMD Instinct GPUs, so they must run on the
@@ -157,7 +125,6 @@ jobs:
           echo "instinct_skills=$instinct_skills" >> "$GITHUB_OUTPUT"
           echo "instinct=$has_instinct" >> "$GITHUB_OUTPUT"
           echo "instinct_run=$instinct_run" >> "$GITHUB_OUTPUT"
-          echo "run_routing=$run_routing" >> "$GITHUB_OUTPUT"
           if [ "$strix" = "[]" ]; then
             echo "strix_any=false" >> "$GITHUB_OUTPUT"
           else
@@ -300,74 +267,6 @@ jobs:
           echo "Running $test_file"
           python -m pytest -c pytest.ini -p conftest "$test_file"
 
-  # Routing eval: install every skill published in
-  # .claude-plugin/marketplace.json at once and check that each prompt in
-  # eval/routing/prompts.json activates the skill it should -- and that the
-  # prompts which should activate nothing don't. Reports statistics
-  # (accuracy, per-skill recall/precision, a confusion matrix) to the job
-  # summary; see eval/routing/routing_eval.py.
-  #
-  # Dispatch-only, and deliberately a single job rather than an OS matrix: a
-  # routing decision is made from skill descriptions alone, so it needs no GPU
-  # and no second platform. It stays on a self-hosted Linux runner only because
-  # that is what can reach the internal LLM gateway.
-  routing:
-    name: Skill routing (all marketplace skills)
-    needs: discover
-    if: needs.discover.outputs.run_routing == 'true'
-    runs-on: [self-hosted, strix_halo, Linux]
-    # Each of the 23 cases is killed as soon as its routing decision is
-    # observable, so the run is far shorter than a behavioral one; the cap is
-    # here to catch a hung agent.
-    timeout-minutes: 30
-    env:
-      ANTHROPIC_API_KEY: ${{ secrets.ORCHESTR_API_KEY }}
-      ANTHROPIC_BASE_URL: https://llm-api.amd.com/Anthropic
-      ANTHROPIC_CUSTOM_HEADERS: |
-        Ocp-Apim-Subscription-Key: ${{ secrets.ORCHESTR_API_KEY }}
-        user: a1_ucicd
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Set up Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install the claude CLI
-        run: npm install -g @anthropic-ai/claude-code
-
-      # No pip install: the routing runner and the harness it borrows from use
-      # only the standard library (pytest is a behavioral-test dependency).
-      #
-      # The eval reports rather than gates, so a low score shows up as
-      # statistics instead of a red run. Add `--min-accuracy 0.9` here to turn
-      # it into a hard bar. It still fails on infrastructure problems (no case
-      # produced a decision, or no skill activated anywhere).
-      - name: Run the skill-routing eval
-        shell: bash
-        run: |
-          set -euo pipefail
-          python eval/routing/routing_eval.py \
-            --output routing-report.json \
-            --keep-logs routing-logs
-
-      - name: Upload routing report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: routing-report
-          path: |
-            routing-report.json
-            routing-logs/
-          if-no-files-found: warn
-
   # Single aggregate gate. Mark THIS check required in branch protection.
   #
   #   * nothing testable changed -> pass (neutral).
@@ -375,22 +274,19 @@ jobs:
   #
   # The Instinct leg is only gated on when it was actually requested, so a PR
   # that touches one of those skills without the `enable_mi_ci` label is not
-  # blocked by a test it deliberately skipped. The routing leg is gated the
-  # same way: it only ever runs on a manual dispatch, so PRs are unaffected.
+  # blocked by a test it deliberately skipped.
   behavioral-gate:
     name: behavioral
-    needs: [discover, behavioral, behavioral-instinct, routing]
+    needs: [discover, behavioral, behavioral-instinct]
     if: always()
     runs-on: ubuntu-latest
     env:
       DISCOVER_RESULT: ${{ needs.discover.result }}
       BEHAVIORAL_RESULT: ${{ needs.behavioral.result }}
       INSTINCT_RESULT: ${{ needs.behavioral-instinct.result }}
-      ROUTING_RESULT: ${{ needs.routing.result }}
       STRIX_ANY: ${{ needs.discover.outputs.strix_any }}
       INSTINCT_AFFECTED: ${{ needs.discover.outputs.instinct }}
       INSTINCT_REQUESTED: ${{ needs.discover.outputs.instinct_run }}
-      ROUTING_REQUESTED: ${{ needs.discover.outputs.run_routing }}
       STRIX_SKILLS: ${{ needs.discover.outputs.strix_skills }}
       INSTINCT_SKILLS: ${{ needs.discover.outputs.instinct_skills }}
     steps:
@@ -399,11 +295,9 @@ jobs:
           echo "discover:            $DISCOVER_RESULT"
           echo "behavioral (strix):  $BEHAVIORAL_RESULT"
           echo "behavioral-instinct: $INSTINCT_RESULT"
-          echo "routing:             $ROUTING_RESULT"
           echo "strix affected:      $STRIX_ANY ($STRIX_SKILLS)"
           echo "instinct affected:   $INSTINCT_AFFECTED ($INSTINCT_SKILLS)"
           echo "instinct requested:  $INSTINCT_REQUESTED"
-          echo "routing requested:   $ROUTING_REQUESTED"
 
           # If discovery itself failed, surface that rather than guessing.
           if [ "$DISCOVER_RESULT" != "success" ]; then
@@ -418,10 +312,8 @@ jobs:
                  "'enable_mi_ci' label, so the MI300X behavioral tests did not run."
           fi
 
-          # No skill or behavioral test changed, and no routing run requested:
-          # nothing to gate on.
-          if [ "$STRIX_ANY" != "true" ] && [ "$INSTINCT_REQUESTED" != "true" ] \
-             && [ "$ROUTING_REQUESTED" != "true" ]; then
+          # No skill or behavioral test changed: nothing to gate on.
+          if [ "$STRIX_ANY" != "true" ] && [ "$INSTINCT_REQUESTED" != "true" ]; then
             echo "No behavioral tests affected by this change."
             exit 0
           fi
@@ -435,10 +327,6 @@ jobs:
           fi
           if [ "$INSTINCT_REQUESTED" = "true" ] && [ "$INSTINCT_RESULT" != "success" ]; then
             echo "Instinct behavioral test did not pass ($INSTINCT_RESULT)." >&2
-            failed=1
-          fi
-          if [ "$ROUTING_REQUESTED" = "true" ] && [ "$ROUTING_RESULT" != "success" ]; then
-            echo "Skill routing eval did not pass ($ROUTING_RESULT)." >&2
             failed=1
           fi
           if [ "$failed" -ne 0 ]; then

--- a/.github/workflows/behavioral.yml
+++ b/.github/workflows/behavioral.yml
@@ -14,10 +14,6 @@ name: behavioral
 #   * opt-in for Instinct -- the MI300X leg is scarce and expensive, so it only
 #     runs on PRs carrying the `enable_mi_ci` label (see behavioral-instinct).
 #
-# The companion question -- "with the whole published catalog installed, does
-# the agent pick the right skill at all?" -- is the routing eval, which lives in
-# its own dispatch-only workflow (routing.yml, eval/routing/).
-#
 # Shape mirrors validate.yml: discover -> matrix -> single aggregate gate, so
 # branch protection can require just the `behavioral` check.
 

--- a/.github/workflows/behavioral.yml
+++ b/.github/workflows/behavioral.yml
@@ -14,6 +14,12 @@ name: behavioral
 #   * opt-in for Instinct -- the MI300X leg is scarce and expensive, so it only
 #     runs on PRs carrying the `enable_mi_ci` label (see behavioral-instinct).
 #
+# This workflow also hosts the *routing* eval (see the `routing` job and
+# eval/routing/): where a behavioral test asks "once this skill runs, does it
+# work?", the routing eval asks "with the whole published catalog installed,
+# does the agent pick the right skill at all?". It is dispatch-only -- pick
+# `routing` from the `mode` dropdown when you run this workflow by hand.
+#
 # Shape mirrors validate.yml: discover -> matrix -> single aggregate gate, so
 # branch protection can require just the `behavioral` check.
 
@@ -31,8 +37,17 @@ on:
       - ".github/scripts/select_behavioral.py"
   workflow_dispatch:
     inputs:
+      mode:
+        description: "behavioral = per-skill behavioral tests. routing = the skill-routing eval over eval/routing/prompts.json. both = run each."
+        type: choice
+        required: false
+        default: behavioral
+        options:
+          - behavioral
+          - routing
+          - both
       skills:
-        description: "Comma-separated skill names to test (blank = every skill that has a behavioral test)."
+        description: "Comma-separated skill names to test (blank = every skill that has a behavioral test). Ignored when mode is routing."
         required: false
         default: ""
 
@@ -59,6 +74,8 @@ jobs:
       instinct: ${{ steps.select.outputs.instinct }}
       # ...versus whether they should actually run, which also needs the label.
       instinct_run: ${{ steps.select.outputs.instinct_run }}
+      # Which of the two evals this run is for (see the `mode` dispatch input).
+      run_routing: ${{ steps.select.outputs.run_routing }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -73,6 +90,18 @@ jobs:
         id: select
         run: |
           set -euo pipefail
+          # The routing eval is dispatch-only: it costs tokens on every prompt
+          # and answers a catalog-wide question, so it is never worth running
+          # automatically on a PR that touches one skill.
+          run_behavioral=true
+          run_routing=false
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            case "${{ github.event.inputs.mode }}" in
+              routing) run_behavioral=false; run_routing=true ;;
+              both)    run_routing=true ;;
+            esac
+          fi
+
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             if [ -n "${{ github.event.inputs.skills }}" ]; then
               skills=$(uv run .github/scripts/select_behavioral.py --names "${{ github.event.inputs.skills }}")
@@ -85,6 +114,14 @@ jobs:
             skills=$(git diff --name-only "$base" "$head" \
               | uv run .github/scripts/select_behavioral.py --changed)
           fi
+
+          # Routing-only run: empty the behavioral matrix. Every downstream
+          # flag is derived from this list, so the strix and Instinct legs skip
+          # and the gate correctly has nothing to enforce for them.
+          if [ "$run_behavioral" != "true" ]; then
+            skills="[]"
+          fi
+          echo "Mode: ${{ github.event.inputs.mode }} (behavioral: $run_behavioral, routing: $run_routing)"
           echo "Selected skills: $skills"
 
           # These skills exercise AMD Instinct GPUs, so they must run on the
@@ -120,6 +157,7 @@ jobs:
           echo "instinct_skills=$instinct_skills" >> "$GITHUB_OUTPUT"
           echo "instinct=$has_instinct" >> "$GITHUB_OUTPUT"
           echo "instinct_run=$instinct_run" >> "$GITHUB_OUTPUT"
+          echo "run_routing=$run_routing" >> "$GITHUB_OUTPUT"
           if [ "$strix" = "[]" ]; then
             echo "strix_any=false" >> "$GITHUB_OUTPUT"
           else
@@ -262,6 +300,74 @@ jobs:
           echo "Running $test_file"
           python -m pytest -c pytest.ini -p conftest "$test_file"
 
+  # Routing eval: install every skill published in
+  # .claude-plugin/marketplace.json at once and check that each prompt in
+  # eval/routing/prompts.json activates the skill it should -- and that the
+  # prompts which should activate nothing don't. Reports statistics
+  # (accuracy, per-skill recall/precision, a confusion matrix) to the job
+  # summary; see eval/routing/routing_eval.py.
+  #
+  # Dispatch-only, and deliberately a single job rather than an OS matrix: a
+  # routing decision is made from skill descriptions alone, so it needs no GPU
+  # and no second platform. It stays on a self-hosted Linux runner only because
+  # that is what can reach the internal LLM gateway.
+  routing:
+    name: Skill routing (all marketplace skills)
+    needs: discover
+    if: needs.discover.outputs.run_routing == 'true'
+    runs-on: [self-hosted, strix_halo, Linux]
+    # Each of the 23 cases is killed as soon as its routing decision is
+    # observable, so the run is far shorter than a behavioral one; the cap is
+    # here to catch a hung agent.
+    timeout-minutes: 30
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ORCHESTR_API_KEY }}
+      ANTHROPIC_BASE_URL: https://llm-api.amd.com/Anthropic
+      ANTHROPIC_CUSTOM_HEADERS: |
+        Ocp-Apim-Subscription-Key: ${{ secrets.ORCHESTR_API_KEY }}
+        user: a1_ucicd
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install the claude CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      # No pip install: the routing runner and the harness it borrows from use
+      # only the standard library (pytest is a behavioral-test dependency).
+      #
+      # The eval reports rather than gates, so a low score shows up as
+      # statistics instead of a red run. Add `--min-accuracy 0.9` here to turn
+      # it into a hard bar. It still fails on infrastructure problems (no case
+      # produced a decision, or no skill activated anywhere).
+      - name: Run the skill-routing eval
+        shell: bash
+        run: |
+          set -euo pipefail
+          python eval/routing/routing_eval.py \
+            --output routing-report.json \
+            --keep-logs routing-logs
+
+      - name: Upload routing report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: routing-report
+          path: |
+            routing-report.json
+            routing-logs/
+          if-no-files-found: warn
+
   # Single aggregate gate. Mark THIS check required in branch protection.
   #
   #   * nothing testable changed -> pass (neutral).
@@ -269,19 +375,22 @@ jobs:
   #
   # The Instinct leg is only gated on when it was actually requested, so a PR
   # that touches one of those skills without the `enable_mi_ci` label is not
-  # blocked by a test it deliberately skipped.
+  # blocked by a test it deliberately skipped. The routing leg is gated the
+  # same way: it only ever runs on a manual dispatch, so PRs are unaffected.
   behavioral-gate:
     name: behavioral
-    needs: [discover, behavioral, behavioral-instinct]
+    needs: [discover, behavioral, behavioral-instinct, routing]
     if: always()
     runs-on: ubuntu-latest
     env:
       DISCOVER_RESULT: ${{ needs.discover.result }}
       BEHAVIORAL_RESULT: ${{ needs.behavioral.result }}
       INSTINCT_RESULT: ${{ needs.behavioral-instinct.result }}
+      ROUTING_RESULT: ${{ needs.routing.result }}
       STRIX_ANY: ${{ needs.discover.outputs.strix_any }}
       INSTINCT_AFFECTED: ${{ needs.discover.outputs.instinct }}
       INSTINCT_REQUESTED: ${{ needs.discover.outputs.instinct_run }}
+      ROUTING_REQUESTED: ${{ needs.discover.outputs.run_routing }}
       STRIX_SKILLS: ${{ needs.discover.outputs.strix_skills }}
       INSTINCT_SKILLS: ${{ needs.discover.outputs.instinct_skills }}
     steps:
@@ -290,9 +399,11 @@ jobs:
           echo "discover:            $DISCOVER_RESULT"
           echo "behavioral (strix):  $BEHAVIORAL_RESULT"
           echo "behavioral-instinct: $INSTINCT_RESULT"
+          echo "routing:             $ROUTING_RESULT"
           echo "strix affected:      $STRIX_ANY ($STRIX_SKILLS)"
           echo "instinct affected:   $INSTINCT_AFFECTED ($INSTINCT_SKILLS)"
           echo "instinct requested:  $INSTINCT_REQUESTED"
+          echo "routing requested:   $ROUTING_REQUESTED"
 
           # If discovery itself failed, surface that rather than guessing.
           if [ "$DISCOVER_RESULT" != "success" ]; then
@@ -307,8 +418,10 @@ jobs:
                  "'enable_mi_ci' label, so the MI300X behavioral tests did not run."
           fi
 
-          # No skill or behavioral test changed: nothing to gate on.
-          if [ "$STRIX_ANY" != "true" ] && [ "$INSTINCT_REQUESTED" != "true" ]; then
+          # No skill or behavioral test changed, and no routing run requested:
+          # nothing to gate on.
+          if [ "$STRIX_ANY" != "true" ] && [ "$INSTINCT_REQUESTED" != "true" ] \
+             && [ "$ROUTING_REQUESTED" != "true" ]; then
             echo "No behavioral tests affected by this change."
             exit 0
           fi
@@ -322,6 +435,10 @@ jobs:
           fi
           if [ "$INSTINCT_REQUESTED" = "true" ] && [ "$INSTINCT_RESULT" != "success" ]; then
             echo "Instinct behavioral test did not pass ($INSTINCT_RESULT)." >&2
+            failed=1
+          fi
+          if [ "$ROUTING_REQUESTED" = "true" ] && [ "$ROUTING_RESULT" != "success" ]; then
+            echo "Skill routing eval did not pass ($ROUTING_RESULT)." >&2
             failed=1
           fi
           if [ "$failed" -ne 0 ]; then

--- a/.github/workflows/routing.yml
+++ b/.github/workflows/routing.yml
@@ -1,0 +1,103 @@
+name: routing
+
+# Routing eval: install every skill published in
+# .claude-plugin/marketplace.json at once and check that each prompt in
+# eval/routing/prompts.json activates the skill it should -- and that the
+# prompts which should activate nothing don't. Reports statistics (accuracy,
+# per-skill recall/precision, a confusion matrix) to the job summary; see
+# eval/routing/routing_eval.py.
+#
+# Where a behavioral test (behavioral.yml, eval/behavioral/) asks "once this
+# skill runs, does it work?", this asks the question that comes first: "with the
+# whole published catalog installed, does the agent pick the right skill at
+# all?".
+#
+# Dispatch-only. The eval costs tokens on every prompt and answers a
+# catalog-wide question, so it is never worth running automatically on a PR that
+# touches one skill -- run it by hand from the Actions tab after changing skill
+# descriptions or the prompt set.
+#
+# Deliberately a single job rather than an OS matrix: a routing decision is made
+# from skill descriptions alone, so it needs no GPU and no second platform. It
+# stays on a self-hosted Linux runner only because that is what can reach the
+# internal LLM gateway.
+
+on:
+  workflow_dispatch:
+    inputs:
+      only:
+        description: "Comma-separated case ids or expected skill names to run (blank = every case in eval/routing/prompts.json)."
+        required: false
+        default: ""
+      min_accuracy:
+        description: "Fail the run when accuracy falls below this (0-1). 0 reports without gating."
+        required: false
+        default: "0"
+
+concurrency:
+  group: routing-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  routing:
+    name: Skill routing (all marketplace skills)
+    runs-on: [self-hosted, strix_halo, Linux]
+    # Each case is killed as soon as its routing decision is observable, so the
+    # run is far shorter than a behavioral one; the cap is here to catch a hung
+    # agent.
+    timeout-minutes: 30
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ORCHESTR_API_KEY }}
+      ANTHROPIC_BASE_URL: https://llm-api.amd.com/Anthropic
+      ANTHROPIC_CUSTOM_HEADERS: |
+        Ocp-Apim-Subscription-Key: ${{ secrets.ORCHESTR_API_KEY }}
+        user: a1_ucicd
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install the claude CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      # No pip install: the routing runner and the harness it borrows from use
+      # only the standard library (pytest is a behavioral-test dependency).
+      #
+      # By default the eval reports rather than gates, so a low score shows up
+      # as statistics instead of a red run; set `min_accuracy` on dispatch to
+      # turn it into a hard bar. It still fails on infrastructure problems (no
+      # case produced a decision, or no skill activated anywhere).
+      - name: Run the skill-routing eval
+        shell: bash
+        env:
+          ONLY: ${{ inputs.only }}
+          MIN_ACCURACY: ${{ inputs.min_accuracy }}
+        run: |
+          set -euo pipefail
+          python eval/routing/routing_eval.py \
+            --only "$ONLY" \
+            --min-accuracy "$MIN_ACCURACY" \
+            --output routing-report.json \
+            --keep-logs routing-logs
+
+      - name: Upload routing report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: routing-report
+          path: |
+            routing-report.json
+            routing-logs/
+          if-no-files-found: warn

--- a/eval/routing/prompts.json
+++ b/eval/routing/prompts.json
@@ -92,13 +92,13 @@
       "id": "analyze-torch-trace",
       "category": "positive",
       "expect": "tracelens-analysis-orchestrator",
-      "prompt": "Analyze the PyTorch profiler trace at traces/step5.json and tell me where the time is going."
+      "prompt": "I profiled a training step with the PyTorch profiler. Analyze the trace at traces/step5.json end to end and write up where the time is going."
     },
     {
       "id": "compare-two-traces",
       "category": "positive",
       "expect": "tracelens-analysis-orchestrator",
-      "prompt": "Compare these two torch traces, baseline.json and tuned.json, and write up what regressed between them."
+      "prompt": "I have PyTorch profiler traces from before and after a tuning change, baseline.json and tuned.json. Run the full comparison and write up which kernels regressed."
     },
     {
       "id": "agentic-analysis-workflow",

--- a/eval/routing/prompts.json
+++ b/eval/routing/prompts.json
@@ -25,8 +25,8 @@
     {
       "id": "tts-offline",
       "category": "positive",
-      "expect": "local-ai-use",
-      "prompt": "Stop sending text to a paid speech vendor for this project. I want anything you read aloud synthesized offline on this laptop."
+      "expect": "local-ai-app-integration",
+      "prompt": "Stop sending text to a paid speech vendor for this app. I want anything you read aloud synthesized offline on this laptop."
     },
     {
       "id": "transcribe-private",
@@ -38,7 +38,7 @@
       "id": "split-routing",
       "category": "positive",
       "expect": "local-ai-use",
-      "prompt": "From now on in this repo, use local models for pictures and audio but keep using the cloud for chat."
+      "prompt": "From now on on Claude, use local models for generating pictures and audio but keep using the cloud for chat."
     },
     {
       "id": "electron-offline-mode",

--- a/eval/routing/prompts.json
+++ b/eval/routing/prompts.json
@@ -1,0 +1,158 @@
+{
+  "_comment": [
+    "Routing prompts for eval/routing/routing_eval.py. Every marketplace skill is",
+    "installed for every case, so each prompt measures a real routing decision made",
+    "against the full published catalog.",
+    "",
+    "Fields:",
+    "  id       -- stable slug, used to filter runs (--only) and to name log files.",
+    "  prompt   -- what the user says. Deliberately phrased the way a user would,",
+    "              not lifted from the skill description: copying description text",
+    "              measures string matching rather than routing.",
+    "  expect   -- the skill that must activate, or null when no skill should fire.",
+    "  category -- positive  = a skill is expected.",
+    "              near_miss = no skill expected, but the prompt sits close to one",
+    "                          (shared vocabulary, explicit out-of-scope hardware).",
+    "              unrelated = no skill expected and nothing in the catalog is close."
+  ],
+  "cases": [
+    {
+      "id": "images-cost",
+      "category": "positive",
+      "expect": "local-ai-use",
+      "prompt": "I'm burning way too much money on image generation API calls. Can you make this workspace generate images on my own machine instead?"
+    },
+    {
+      "id": "tts-offline",
+      "category": "positive",
+      "expect": "local-ai-use",
+      "prompt": "Stop sending text to a paid speech vendor for this project. I want anything you read aloud synthesized offline on this laptop."
+    },
+    {
+      "id": "transcribe-private",
+      "category": "positive",
+      "expect": "local-ai-use",
+      "prompt": "Transcribe meeting.wav for me, and keep the audio on this device instead of uploading it to a transcription service."
+    },
+    {
+      "id": "split-routing",
+      "category": "positive",
+      "expect": "local-ai-use",
+      "prompt": "From now on in this repo, use local models for pictures and audio but keep using the cloud for chat."
+    },
+    {
+      "id": "electron-offline-mode",
+      "category": "positive",
+      "expect": "local-ai-app-integration",
+      "prompt": "My Electron app calls the OpenAI chat completions endpoint. I want to ship an offline mode that bundles the inference engine into the installer so it still works with no internet."
+    },
+    {
+      "id": "swap-anthropic-backend",
+      "category": "positive",
+      "expect": "local-ai-app-integration",
+      "prompt": "My Python desktop tool talks to the Anthropic Messages API today. Give it a mode where the model runs on the customer's own PC so their data never leaves the machine."
+    },
+    {
+      "id": "vendor-binary",
+      "category": "positive",
+      "expect": "local-ai-app-integration",
+      "prompt": "Can you vendor an inference binary into my app and repoint my existing HTTP client at it instead of the Ollama server I'm hitting now?"
+    },
+    {
+      "id": "in-app-embeddings",
+      "category": "positive",
+      "expect": "local-ai-app-integration",
+      "prompt": "I want my app to compute embeddings on the end user's hardware rather than calling a hosted embeddings API. How do I wire that up?"
+    },
+    {
+      "id": "qwen-on-mi300x",
+      "category": "positive",
+      "expect": "serving-llms-on-instinct",
+      "prompt": "Get Qwen3 serving on my MI300X box."
+    },
+    {
+      "id": "vllm-rocm-node",
+      "category": "positive",
+      "expect": "serving-llms-on-instinct",
+      "prompt": "I have an 8-GPU AMD Instinct node with ROCm installed. Spin up a vLLM endpoint for DeepSeek and confirm it's actually healthy before you hand it back to me."
+    },
+    {
+      "id": "openai-compatible-mi355x",
+      "category": "positive",
+      "expect": "serving-llms-on-instinct",
+      "prompt": "How do I launch an OpenAI-compatible inference server on MI355X hardware?"
+    },
+    {
+      "id": "deploy-datacenter-gpu",
+      "category": "positive",
+      "expect": "serving-llms-on-instinct",
+      "prompt": "Deploy a language model on my AMD data center GPUs so my team can hit it over HTTP."
+    },
+    {
+      "id": "analyze-torch-trace",
+      "category": "positive",
+      "expect": "tracelens-analysis-orchestrator",
+      "prompt": "Analyze the PyTorch profiler trace at traces/step5.json and tell me where the time is going."
+    },
+    {
+      "id": "compare-two-traces",
+      "category": "positive",
+      "expect": "tracelens-analysis-orchestrator",
+      "prompt": "Compare these two torch traces, baseline.json and tuned.json, and write up what regressed between them."
+    },
+    {
+      "id": "agentic-analysis-workflow",
+      "category": "positive",
+      "expect": "tracelens-analysis-orchestrator",
+      "prompt": "Run the agentic analysis workflow on my trace and produce analysis.md."
+    },
+    {
+      "id": "kernel-perf-report",
+      "category": "positive",
+      "expect": "tracelens-analysis-orchestrator",
+      "prompt": "I captured a GPU kernel trace from a training run. I need a prioritized report of the worst performance offenders that I can show stakeholders."
+    },
+    {
+      "id": "vllm-on-nvidia",
+      "category": "near_miss",
+      "expect": null,
+      "prompt": "Serve Llama 3.1 70B with vLLM on my NVIDIA H100 cluster."
+    },
+    {
+      "id": "consumer-radeon",
+      "category": "near_miss",
+      "expect": null,
+      "prompt": "Which quantization should I pick to fit a 13B model into the 16 GB on my Radeon RX 7800 XT?"
+    },
+    {
+      "id": "hbm-vs-gddr",
+      "category": "near_miss",
+      "expect": null,
+      "prompt": "Explain the practical difference between HBM3 and GDDR6 memory bandwidth for inference workloads."
+    },
+    {
+      "id": "node-event-loop",
+      "category": "near_miss",
+      "expect": null,
+      "prompt": "My Node.js server shows high event loop latency under load. Help me profile it and find the blocking call."
+    },
+    {
+      "id": "merge-sorted-lists",
+      "category": "unrelated",
+      "expect": null,
+      "prompt": "Write a Python function that merges two sorted lists, and add unit tests for it."
+    },
+    {
+      "id": "windows-path-bug",
+      "category": "unrelated",
+      "expect": null,
+      "prompt": "My pytest run fails with a Windows path error in test_utils.py. Track down the bug and fix it."
+    },
+    {
+      "id": "ruff-ci-job",
+      "category": "unrelated",
+      "expect": null,
+      "prompt": "Add a GitHub Actions job that runs ruff on every pull request."
+    }
+  ]
+}

--- a/eval/routing/prompts.json
+++ b/eval/routing/prompts.json
@@ -8,7 +8,12 @@
     "  id       -- stable slug, used to filter runs (--only) and to name log files.",
     "  prompt   -- what the user says. Deliberately phrased the way a user would,",
     "              not lifted from the skill description: copying description text",
-    "              measures string matching rather than routing.",
+    "              measures string matching rather than routing. Prompts that hand",
+    "              over a profiler trace link a real one from the TraceLens test",
+    "              fixtures, because the staged workspace holds nothing but the",
+    "              skills tree: a prompt that claims a trace is on disk when none",
+    "              is sends the agent hunting for a file that cannot exist, and it",
+    "              can end the turn asking where the trace is without ever routing.",
     "  expect   -- the skill that must activate, or null when no skill should fire.",
     "  category -- positive  = a skill is expected.",
     "              near_miss = no skill expected, but the prompt sits close to one",
@@ -25,8 +30,8 @@
     {
       "id": "tts-offline",
       "category": "positive",
-      "expect": "local-ai-app-integration",
-      "prompt": "Stop sending text to a paid speech vendor for this app. I want anything you read aloud synthesized offline on this laptop."
+      "expect": "local-ai-use",
+      "prompt": "Stop sending text to a paid cloud TTS service. From now on, I want anything you read aloud synthesized offline on this laptop."
     },
     {
       "id": "transcribe-private",
@@ -92,25 +97,25 @@
       "id": "analyze-torch-trace",
       "category": "positive",
       "expect": "tracelens-analysis-orchestrator",
-      "prompt": "My training step is way slower than I expected. I ran it under the PyTorch profiler and have the output sitting on disk. Work out where the time is actually going and write it up so I know what to fix first."
+      "prompt": "My training step is way slower than I expected. I ran it under the PyTorch profiler and the output is at https://github.com/AMD-AGI/TraceLens/raw/main/tests/traces/mi300/resnet_act_checkpoint.json.gz. Work out where the time is actually going and write it up so I know what to fix first."
     },
     {
       "id": "compare-two-traces",
       "category": "positive",
       "expect": "tracelens-analysis-orchestrator",
-      "prompt": "I tuned a training config and captured PyTorch profiler runs on either side of the change. One is clearly slower and I can't tell why. Tell me which GPU kernels regressed between the two runs, worst first, and write it up."
+      "prompt": "I profiled the same model on two different machines and one is clearly slower, but I can't tell why. The captures are at https://github.com/AMD-AGI/TraceLens/raw/main/tests/traces/mi300/facebook_timesformer-base-finetuned-k400__1016002.json.gz and https://github.com/AMD-AGI/TraceLens/raw/main/tests/traces/h100/facebook_timesformer-base-finetuned-k400__1016002.json.gz. Tell me which GPU kernels are worse on the slow one, worst first, and write it up."
     },
     {
       "id": "agentic-analysis-workflow",
       "category": "positive",
       "expect": "tracelens-analysis-orchestrator",
-      "prompt": "Run the agentic analysis workflow on my trace and produce analysis.md."
+      "prompt": "Run the agentic analysis workflow on the trace at https://github.com/AMD-AGI/TraceLens/raw/main/tests/traces/mi300/gaunernst_bert-small-uncased__1016001.json.gz and produce analysis.md."
     },
     {
       "id": "kernel-perf-report",
       "category": "positive",
       "expect": "tracelens-analysis-orchestrator",
-      "prompt": "I captured a GPU kernel trace from a training run. I need a prioritized report of the worst performance offenders that I can show stakeholders."
+      "prompt": "I captured a GPU kernel trace from a distributed training run: https://github.com/AMD-AGI/TraceLens/raw/main/tests/traces/mi300/llama_70b_fsdp/rank0_trace_no_pyfn.json.gz. I need a prioritized report of the worst performance offenders that I can show stakeholders."
     },
     {
       "id": "vllm-on-nvidia",

--- a/eval/routing/prompts.json
+++ b/eval/routing/prompts.json
@@ -92,13 +92,13 @@
       "id": "analyze-torch-trace",
       "category": "positive",
       "expect": "tracelens-analysis-orchestrator",
-      "prompt": "I profiled a training step with the PyTorch profiler. Analyze the trace at traces/step5.json end to end and write up where the time is going."
+      "prompt": "My training step is way slower than I expected. I ran it under the PyTorch profiler and have the output sitting on disk. Work out where the time is actually going and write it up so I know what to fix first."
     },
     {
       "id": "compare-two-traces",
       "category": "positive",
       "expect": "tracelens-analysis-orchestrator",
-      "prompt": "I have PyTorch profiler traces from before and after a tuning change, baseline.json and tuned.json. Run the full comparison and write up which kernels regressed."
+      "prompt": "I tuned a training config and captured PyTorch profiler runs on either side of the change. One is clearly slower and I can't tell why. Tell me which GPU kernels regressed between the two runs, worst first, and write it up."
     },
     {
       "id": "agentic-analysis-workflow",

--- a/eval/routing/prompts.json
+++ b/eval/routing/prompts.json
@@ -38,7 +38,7 @@
       "id": "split-routing",
       "category": "positive",
       "expect": "local-ai-use",
-      "prompt": "From now on on Claude, use local models for generating pictures and audio but keep using the cloud for chat."
+      "prompt": "From now on, when using Claude, use local models for generating pictures but keep using the cloud for chat."
     },
     {
       "id": "electron-offline-mode",

--- a/eval/routing/routing_eval.py
+++ b/eval/routing/routing_eval.py
@@ -253,8 +253,31 @@ def _match_skill(text: str, skills: list[str]) -> str | None:
     return None
 
 
+def _skill_from_body_path(text: str, skills: list[str]) -> str | None:
+    """The skill whose own ``SKILL.md`` path appears in `text`, or None.
+
+    Matching the joined ``skills/<name>/skill.md`` path -- never the bare
+    filename, never the bare skill name -- is what separates "this skill's
+    body was loaded" from "this text happens to mention the skill". Two or
+    more matches mean the text enumerates the catalog, which is a listing
+    rather than a decision, so that is not an activation either.
+    """
+    haystack = text.lower().replace("\\\\", "/").replace("\\", "/")
+    hits = [skill for skill in skills if f"skills/{skill.lower()}/skill.md" in haystack]
+    return hits[0] if len(hits) == 1 else None
+
+
 def detect_activation(event: dict, skills: list[str]) -> str | None:
     """The skill this event activates, or None.
+
+    Only the agent's own tool calls count. Tool *results* and assistant prose
+    are deliberately excluded: the staged workspace holds nothing but the
+    skills tree, so any prompt that sends the agent looking for a file it
+    cannot find gets a recursive listing of every ``SKILL.md`` back. Scoring
+    that as an activation credited the longest skill name in the catalog with
+    a false trigger on unrelated prompts, and -- worse -- scored a correct
+    trigger whenever an expected skill's prompt named a path that did not
+    exist, hiding real misses behind the file hunt.
 
     Returns ``"other:<name>"`` when a skill outside the marketplace fires --
     that is a contaminated runner, not a routing result, and the report should
@@ -279,19 +302,18 @@ def detect_activation(event: dict, skills: list[str]) -> str | None:
             return f"other:{invoked or 'unknown'}"
 
         # Fallback for builds that load a skill body by reading the file
-        # instead of going through the Skill tool.
-        hit = _match_skill(tool_input, skills)
-        if hit and ("skill.md" in tool_input.lower() or ".claude/skills" in tool_input.lower()):
+        # instead of going through the Skill tool. The call itself has to
+        # target that skill's own SKILL.md; merely touching the skills
+        # directory (`ls .claude/skills`) is not a routing decision.
+        hit = _skill_from_body_path(tool_input, skills)
+        if hit:
             return hit
 
-    # Last resort, independent of tool naming: a skill body can only reach the
-    # context through its own SKILL.md path, so seeing that exact path
-    # anywhere in the event means the skill loaded. Matching the joined path
-    # (not the bare filename) keeps a directory listing from counting.
-    blob = json.dumps(event, ensure_ascii=False).lower().replace("\\\\", "/").replace("\\", "/")
-    for skill in sorted(skills, key=len, reverse=True):
-        if f"skills/{skill.lower()}/skill.md" in blob:
-            return skill
+    # Some builds announce an activation as a system event instead of a tool
+    # call. Same joined-path rule, and init is excluded because it enumerates
+    # the whole catalog by design.
+    if event.get("type") == "system" and event.get("subtype") != "init":
+        return _skill_from_body_path(json.dumps(event, ensure_ascii=False), skills)
     return None
 
 

--- a/eval/routing/routing_eval.py
+++ b/eval/routing/routing_eval.py
@@ -1,0 +1,854 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+
+"""Routing eval: does the right marketplace skill fire, and only then?
+
+A behavioral test (``eval/behavioral/``) asks "once this skill runs, does it do
+the job?". This eval asks the question that comes first: **given every published
+skill installed side by side, does the agent pick the right one?** It grades the
+routing decision only, so it catches the four failure modes a description can
+cause:
+
+  * correct trigger -- the expected skill activated.
+  * missed trigger  -- a skill was expected and none activated (under-triggering).
+  * wrong skill     -- a skill activated, but not the expected one (two
+                       descriptions overlap and the agent picked the wrong side).
+  * false trigger   -- no skill was expected and one activated (over-triggering).
+
+Every case installs **all** skills published in
+``.claude-plugin/marketplace.json`` at once, because that is what a user who
+installs the plugin actually gets. Routing is only meaningful against the whole
+catalog: a skill tested alone will happily answer prompts that belong to its
+neighbor.
+
+Cost control: each run is killed the moment the routing decision is observable
+-- the first skill activation, the final result event, or a small budget of
+non-skill tool calls -- so no case pays for the work the skill would have gone
+on to do. ``--max-budget-usd`` is a second, independent backstop.
+
+Usage::
+
+    # every case, JSON + markdown report
+    python eval/routing/routing_eval.py
+
+    # one case, keeping the raw transcript for debugging
+    python eval/routing/routing_eval.py --only qwen-on-mi300x --keep-logs
+
+Output is a JSON artifact (``--output``) plus a markdown report written to
+stdout and, under GitHub Actions, to ``$GITHUB_STEP_SUMMARY``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import queue
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from collections import Counter, defaultdict
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parent.parent
+EVAL_DIR = REPO_ROOT / "eval"
+MARKETPLACE = REPO_ROOT / ".claude-plugin" / "marketplace.json"
+PROMPTS_FILE = HERE / "prompts.json"
+
+# Reuse the behavioral harness for the skill root, the CI model pin, and the
+# API preflight so both evals agree on those. Both directories go on the path
+# because harness.py itself imports claude_eval.
+sys.path.insert(0, str(EVAL_DIR))
+sys.path.insert(0, str(EVAL_DIR / "behavioral"))
+from claude_eval import SKILLS_DIR  # noqa: E402
+from harness import AUTOMATED_MODEL, check_api_reachable  # noqa: E402
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+# Tools that carry no routing signal. An agent often opens with a todo list or
+# a plan before deciding anything, and spending the non-skill tool budget on
+# that would cut the run off before the real decision.
+BOOKKEEPING_TOOLS = {"todowrite", "todoread", "exitplanmode"}
+
+# Tool names Claude Code uses to activate a skill. `Skill` is current; older
+# builds routed skills through the slash-command tool.
+SKILL_TOOLS = {"skill", "slashcommand"}
+
+VERDICTS = ("correct_trigger", "true_negative", "missed_trigger", "wrong_skill", "false_trigger", "error")
+PASSING_VERDICTS = {"correct_trigger", "true_negative"}
+
+# Stop reasons that leave the routing decision unknown rather than observed.
+INCONCLUSIVE_STOPS = {"completed", "timeout"}
+
+
+@dataclass
+class Case:
+    id: str
+    prompt: str
+    expect: str | None
+    category: str
+
+
+@dataclass
+class Outcome:
+    id: str
+    category: str
+    prompt: str
+    expect: str | None
+    observed: str | None
+    verdict: str
+    passed: bool
+    stop_reason: str
+    elapsed_s: float
+    tool_calls: int
+    visible_skills: list[str] = field(default_factory=list)
+    error: str | None = None
+
+
+def is_automated() -> bool:
+    """True under CI / an automated workflow (GitHub Actions sets both)."""
+    return any(
+        os.environ.get(var, "").strip().lower() in _TRUTHY
+        for var in ("CI", "GITHUB_ACTIONS")
+    )
+
+
+def enforce_model_policy(model: str) -> str:
+    """Pin automated runs to opus, matching the behavioral harness."""
+    if not is_automated() or "opus" in model.lower():
+        return model
+    print(f"[routing] automated run: coercing model '{model}' -> '{AUTOMATED_MODEL}'.")
+    return AUTOMATED_MODEL
+
+
+def marketplace_skills() -> list[str]:
+    """Skill names published in the marketplace bundle, in manifest order.
+
+    Read from the manifest rather than hardcoded so publishing or unpublishing
+    a skill changes what this eval installs without touching the eval.
+    """
+    manifest = json.loads(MARKETPLACE.read_text(encoding="utf-8"))
+    plugins = manifest.get("plugins") or []
+    names: list[str] = []
+    for plugin in plugins:
+        for entry in plugin.get("skills") or []:
+            name = str(entry).rstrip("/").split("/")[-1]
+            if name and name not in names:
+                names.append(name)
+
+    missing = [n for n in names if not (SKILLS_DIR / n / "SKILL.md").is_file()]
+    if missing:
+        raise SystemExit(
+            f"error: marketplace lists skills with no SKILL.md: {', '.join(missing)}"
+        )
+    if not names:
+        raise SystemExit(f"error: no skills listed in {MARKETPLACE}")
+    return names
+
+
+def load_cases(path: Path) -> list[Case]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    cases = [
+        Case(
+            id=str(entry["id"]),
+            prompt=str(entry["prompt"]),
+            expect=entry.get("expect") or None,
+            category=str(entry.get("category") or "positive"),
+        )
+        for entry in payload["cases"]
+    ]
+    duplicates = [cid for cid, count in Counter(c.id for c in cases).items() if count > 1]
+    if duplicates:
+        raise SystemExit(f"error: duplicate case ids in {path}: {', '.join(duplicates)}")
+    return cases
+
+
+def stage_workspace(skills: list[str]) -> Path:
+    """Install every marketplace skill into a fresh temp workspace.
+
+    Claude Code loads ``.claude/skills/`` from a directory passed with
+    ``--add-dir``, which registers each skill's name and description in the
+    system prompt without injecting its body -- exactly the state a routing
+    decision is made from. One workspace per case keeps cases isolated (and
+    lets them run concurrently).
+    """
+    workspace = Path(tempfile.mkdtemp(prefix="routing-"))
+    dest_root = workspace / ".claude" / "skills"
+    dest_root.mkdir(parents=True, exist_ok=True)
+    for skill in skills:
+        shutil.copytree(SKILLS_DIR / skill, dest_root / skill)
+    return workspace
+
+
+def supported_flags(flags: list[str]) -> set[str]:
+    """Which of `flags` the installed `claude` build advertises in --help.
+
+    The two cost-control flags this eval likes to pass are recent additions. An
+    older CLI would reject them and every case would fail identically, which
+    reads like a routing collapse rather than a flag problem -- so check once
+    (free, no tokens) and drop what isn't there.
+    """
+    claude_bin = shutil.which("claude")
+    if not claude_bin:
+        return set()
+    try:
+        proc = subprocess.run(
+            [claude_bin, "--help"], capture_output=True, text=True, encoding="utf-8", timeout=60
+        )
+    except (subprocess.SubprocessError, OSError):
+        return set()
+    text = (proc.stdout or "") + (proc.stderr or "")
+    return {flag for flag in flags if flag in text}
+
+
+def claude_env() -> dict[str, str]:
+    """Environment for `claude` subprocesses (fail fast instead of retrying)."""
+    env = dict(os.environ)
+    env.setdefault("CLAUDE_CODE_MAX_RETRIES", "0")
+    return env
+
+
+def _iter_tool_uses(obj) -> list[tuple[str, str]]:
+    """Every (tool name, JSON-encoded tool input) pair nested anywhere in `obj`."""
+    found: list[tuple[str, str]] = []
+
+    def walk(node) -> None:
+        if isinstance(node, dict):
+            if node.get("type") == "tool_use":
+                found.append(
+                    (
+                        str(node.get("name", "")),
+                        json.dumps(node.get("input", {}), ensure_ascii=False),
+                    )
+                )
+            for value in node.values():
+                walk(value)
+        elif isinstance(node, list):
+            for value in node:
+                walk(value)
+
+    walk(obj)
+    return found
+
+
+def _match_skill(text: str, skills: list[str]) -> str | None:
+    """Longest skill name mentioned in `text`, or None.
+
+    Longest-first matters because one skill name can be a prefix of another
+    (`local-ai-use` vs `local-ai-app-integration` share a stem today, and a
+    future skill could nest outright).
+    """
+    lowered = text.lower()
+    for skill in sorted(skills, key=len, reverse=True):
+        if skill.lower() in lowered:
+            return skill
+    return None
+
+
+def detect_activation(event: dict, skills: list[str]) -> str | None:
+    """The skill this event activates, or None.
+
+    Returns ``"other:<name>"`` when a skill outside the marketplace fires --
+    that is a contaminated runner, not a routing result, and the report should
+    say so rather than silently scoring it as a miss.
+    """
+    for name, tool_input in _iter_tool_uses(event):
+        lowered = name.lower()
+        if lowered in SKILL_TOOLS:
+            hit = _match_skill(tool_input, skills)
+            if hit:
+                return hit
+            try:
+                parsed = json.loads(tool_input)
+            except json.JSONDecodeError:
+                parsed = {}
+            invoked = ""
+            for key in ("command", "skill", "name", "skill_name"):
+                value = parsed.get(key) if isinstance(parsed, dict) else None
+                if isinstance(value, str) and value.strip():
+                    invoked = value.strip().lstrip("/")
+                    break
+            return f"other:{invoked or 'unknown'}"
+
+        # Fallback for builds that load a skill body by reading the file
+        # instead of going through the Skill tool.
+        hit = _match_skill(tool_input, skills)
+        if hit and ("skill.md" in tool_input.lower() or ".claude/skills" in tool_input.lower()):
+            return hit
+
+    # Last resort, independent of tool naming: a skill body can only reach the
+    # context through its own SKILL.md path, so seeing that exact path
+    # anywhere in the event means the skill loaded. Matching the joined path
+    # (not the bare filename) keeps a directory listing from counting.
+    blob = json.dumps(event, ensure_ascii=False).lower().replace("\\\\", "/").replace("\\", "/")
+    for skill in sorted(skills, key=len, reverse=True):
+        if f"skills/{skill.lower()}/skill.md" in blob:
+            return skill
+    return None
+
+
+def _init_skills(event: dict, skills: list[str]) -> list[str] | None:
+    """Skill names the CLI reported at session init, if this is that event.
+
+    Used to prove the agent really saw the whole catalog (and nothing extra):
+    a stray user-level skill on the runner would change every routing decision.
+    """
+    if event.get("type") != "system" or event.get("subtype") != "init":
+        return None
+    seen: list[str] = []
+    for key in ("skills", "slash_commands", "slashCommands", "commands"):
+        entries = event.get(key)
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            text = entry if isinstance(entry, str) else json.dumps(entry, ensure_ascii=False)
+            hit = _match_skill(text, skills)
+            if hit and hit not in seen:
+                seen.append(hit)
+    return seen
+
+
+def _pump(stream, sink: queue.Queue) -> None:
+    try:
+        for line in stream:
+            sink.put(line)
+    finally:
+        sink.put(None)
+
+
+def _terminate(proc: subprocess.Popen) -> None:
+    """Kill the CLI and its children.
+
+    The `claude` process spawns helpers, so killing only the parent can leave
+    an orphan holding the API call open -- which is the cost this eval exists
+    to avoid. Kill the whole group/tree.
+    """
+    if proc.poll() is not None:
+        return
+    try:
+        if os.name == "nt":
+            subprocess.run(
+                ["taskkill", "/F", "/T", "/PID", str(proc.pid)],
+                capture_output=True,
+                check=False,
+            )
+        else:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    except (OSError, subprocess.SubprocessError):
+        pass
+    try:
+        proc.kill()
+    except OSError:
+        pass
+    try:
+        proc.wait(timeout=15)
+    except subprocess.TimeoutExpired:
+        pass
+
+
+def run_case(case: Case, skills: list[str], args: argparse.Namespace) -> Outcome:
+    """Run one prompt, stopping as soon as the routing decision is known."""
+    claude_bin = shutil.which("claude")
+    if not claude_bin:
+        raise SystemExit("error: 'claude' CLI not found on PATH")
+
+    workspace = stage_workspace(skills)
+    cmd = [
+        claude_bin,
+        "-p",
+        "--output-format",
+        "stream-json",
+        "--verbose",
+        "--dangerously-skip-permissions",
+        "--add-dir",
+        str(workspace),
+        "--model",
+        args.model,
+    ]
+    if args.effort:
+        cmd += ["--effort", args.effort]
+    # 23 throwaway sessions per run; don't leave them on disk.
+    if "--no-session-persistence" in args.available_flags:
+        cmd += ["--no-session-persistence"]
+    if args.max_budget_usd > 0 and "--max-budget-usd" in args.available_flags:
+        cmd += ["--max-budget-usd", str(args.max_budget_usd)]
+
+    spawn: dict = {}
+    if os.name == "nt":
+        spawn["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+    else:
+        spawn["start_new_session"] = True
+
+    events: list[dict] = []
+    observed: str | None = None
+    visible: list[str] = []
+    stop_reason = "completed"
+    tool_calls = 0
+    error: str | None = None
+    stderr_lines: list[str] = []
+
+    start = time.perf_counter()
+    proc = subprocess.Popen(
+        cmd,
+        cwd=str(workspace),
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        bufsize=1,
+        env=claude_env(),
+        **spawn,
+    )
+    try:
+        assert proc.stdin is not None
+        proc.stdin.write(case.prompt)
+        proc.stdin.close()
+
+        stdout_q: queue.Queue = queue.Queue()
+        threading.Thread(target=_pump, args=(proc.stdout, stdout_q), daemon=True).start()
+        threading.Thread(
+            target=lambda: stderr_lines.extend(proc.stderr.readlines()), daemon=True
+        ).start()
+
+        deadline = time.perf_counter() + args.timeout
+        while True:
+            remaining = deadline - time.perf_counter()
+            if remaining <= 0:
+                stop_reason = "timeout"
+                break
+            try:
+                line = stdout_q.get(timeout=min(1.0, remaining))
+            except queue.Empty:
+                continue
+            if line is None:
+                break
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            events.append(event)
+
+            reported = _init_skills(event, skills)
+            if reported is not None:
+                visible = reported
+
+            hit = detect_activation(event, skills)
+            if hit:
+                observed = hit
+                stop_reason = "skill_activated"
+                break
+
+            if event.get("type") == "result":
+                stop_reason = "result"
+                if event.get("is_error"):
+                    error = str(event.get("result") or "result event reported an error")[:400]
+                break
+
+            tool_calls += sum(
+                1
+                for name, _ in _iter_tool_uses(event)
+                if name.lower() not in BOOKKEEPING_TOOLS
+            )
+            if tool_calls >= args.max_tool_calls:
+                stop_reason = "tool_budget"
+                break
+    finally:
+        _terminate(proc)
+        elapsed = time.perf_counter() - start
+        if args.keep_logs:
+            logs_dir = Path(args.keep_logs)
+            logs_dir.mkdir(parents=True, exist_ok=True)
+            (logs_dir / f"{case.id}.jsonl").write_text(
+                "\n".join(json.dumps(e, ensure_ascii=False) for e in events),
+                encoding="utf-8",
+            )
+        shutil.rmtree(workspace, ignore_errors=True)
+
+    if not events:
+        error = ("".join(stderr_lines).strip() or "claude produced no stream-json output")[:400]
+
+    # "no skill activated" is only a real finding when the run got far enough to
+    # show a decision: the agent answered (`result`) or started doing the work
+    # itself (`tool_budget`). A stream that just ends, or a hang, means the run
+    # never made a routing decision -- grading that as a missed trigger would
+    # invent a result out of an infrastructure failure.
+    if observed is None and stop_reason in INCONCLUSIVE_STOPS:
+        verdict = "error"
+        detail = "".join(stderr_lines).strip()
+        error = error or (
+            f"run ended without a routing decision (stopped after: {stop_reason})"
+            + (f"; stderr: {detail[:300]}" if detail else "")
+        )
+    elif error and observed is None:
+        verdict = "error"
+    else:
+        verdict = classify(case.expect, observed)
+
+    outcome = Outcome(
+        id=case.id,
+        category=case.category,
+        prompt=case.prompt,
+        expect=case.expect,
+        observed=observed,
+        verdict=verdict,
+        passed=verdict in PASSING_VERDICTS,
+        stop_reason=stop_reason,
+        elapsed_s=round(elapsed, 2),
+        tool_calls=tool_calls,
+        visible_skills=visible,
+        error=error,
+    )
+    print(
+        f"  [{'PASS' if outcome.passed else 'FAIL'}] {case.id}: "
+        f"expected {case.expect or 'no skill'} -> got {observed or 'no skill'} "
+        f"({verdict}, {stop_reason}, {outcome.elapsed_s}s)",
+        flush=True,
+    )
+    return outcome
+
+
+def classify(expect: str | None, observed: str | None) -> str:
+    if observed is None:
+        return "true_negative" if expect is None else "missed_trigger"
+    if expect is None:
+        return "false_trigger"
+    return "correct_trigger" if observed == expect else "wrong_skill"
+
+
+def summarize(outcomes: list[Outcome], skills: list[str], meta: dict) -> dict:
+    verdicts = Counter(o.verdict for o in outcomes)
+    graded = [o for o in outcomes if o.verdict != "error"]
+    passed = [o for o in graded if o.passed]
+
+    by_category: dict[str, dict] = {}
+    for category in sorted({o.category for o in outcomes}):
+        subset = [o for o in graded if o.category == category]
+        hits = sum(1 for o in subset if o.passed)
+        by_category[category] = {
+            "graded": len(subset),
+            "passed": hits,
+            "accuracy": round(hits / len(subset), 3) if subset else None,
+        }
+
+    per_skill: dict[str, dict] = {}
+    for skill in skills:
+        expected = [o for o in graded if o.expect == skill]
+        correct = sum(1 for o in expected if o.observed == skill)
+        fired = [o for o in graded if o.observed == skill]
+        false_fires = sum(1 for o in fired if o.expect != skill)
+        per_skill[skill] = {
+            "expected": len(expected),
+            "correct": correct,
+            "missed": sum(1 for o in expected if o.observed is None),
+            "lost_to_other_skill": sum(
+                1 for o in expected if o.observed is not None and o.observed != skill
+            ),
+            "fired_total": len(fired),
+            "fired_when_not_expected": false_fires,
+            "recall": round(correct / len(expected), 3) if expected else None,
+            "precision": round(correct / len(fired), 3) if fired else None,
+        }
+
+    confusion: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    for outcome in graded:
+        confusion[outcome.expect or "(no skill)"][outcome.observed or "(no skill)"] += 1
+
+    contaminated = sorted(
+        {o.observed for o in outcomes if o.observed and o.observed.startswith("other:")}
+    )
+    catalog_gaps = sorted(
+        {
+            skill
+            for o in outcomes
+            if o.visible_skills
+            for skill in skills
+            if skill not in o.visible_skills
+        }
+    )
+
+    return {
+        "meta": meta,
+        "totals": {
+            "cases": len(outcomes),
+            "graded": len(graded),
+            "passed": len(passed),
+            "errors": verdicts.get("error", 0),
+            "accuracy": round(len(passed) / len(graded), 3) if graded else None,
+            # How many runs activated any skill at all. Zero across a set that
+            # expects activations means the skills were never installed or the
+            # activation detector no longer matches the CLI's output -- either
+            # way the numbers are an artifact, not a result.
+            "activations": sum(1 for o in graded if o.observed),
+            "activations_expected": sum(1 for o in graded if o.expect),
+        },
+        "verdicts": {name: verdicts.get(name, 0) for name in VERDICTS},
+        "by_category": by_category,
+        "per_skill": per_skill,
+        "confusion": {k: dict(v) for k, v in confusion.items()},
+        "unexpected_skills": contaminated,
+        "skills_missing_from_session": catalog_gaps,
+        "cases": [asdict(o) for o in outcomes],
+    }
+
+
+def render_markdown(summary: dict) -> str:
+    totals = summary["totals"]
+    verdicts = summary["verdicts"]
+    meta = summary["meta"]
+    accuracy = totals["accuracy"]
+    lines = [
+        "## Skill routing eval",
+        "",
+        f"**{totals['passed']}/{totals['graded']} correct "
+        f"({'n/a' if accuracy is None else f'{accuracy:.1%}'})** across "
+        f"{totals['cases']} prompts with {len(meta['skills'])} marketplace skills "
+        f"installed together, on `{meta['model']}` (effort `{meta['effort']}`).",
+        "",
+        "| Verdict | Count | Meaning |",
+        "| --- | --- | --- |",
+        f"| correct_trigger | {verdicts['correct_trigger']} | expected skill activated |",
+        f"| true_negative | {verdicts['true_negative']} | no skill expected, none activated |",
+        f"| missed_trigger | {verdicts['missed_trigger']} | skill expected, nothing activated |",
+        f"| wrong_skill | {verdicts['wrong_skill']} | a skill activated, but the wrong one |",
+        f"| false_trigger | {verdicts['false_trigger']} | no skill expected, one activated |",
+        f"| error | {verdicts['error']} | the run failed; excluded from accuracy |",
+        "",
+        "### By prompt category",
+        "",
+        "| Category | Graded | Correct | Accuracy |",
+        "| --- | --- | --- | --- |",
+    ]
+    for category, stats in summary["by_category"].items():
+        acc = stats["accuracy"]
+        lines.append(
+            f"| {category} | {stats['graded']} | {stats['passed']} | "
+            f"{'n/a' if acc is None else f'{acc:.0%}'} |"
+        )
+
+    lines += [
+        "",
+        "### Per skill",
+        "",
+        "| Skill | Expected | Correct | Missed | Lost to another skill | Fired when not expected | Recall | Precision |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for skill, stats in summary["per_skill"].items():
+        recall = stats["recall"]
+        precision = stats["precision"]
+        lines.append(
+            f"| `{skill}` | {stats['expected']} | {stats['correct']} | {stats['missed']} | "
+            f"{stats['lost_to_other_skill']} | {stats['fired_when_not_expected']} | "
+            f"{'n/a' if recall is None else f'{recall:.0%}'} | "
+            f"{'n/a' if precision is None else f'{precision:.0%}'} |"
+        )
+
+    # Errors get their own section: a crashed run says nothing about routing,
+    # so listing it as a routing failure would be misleading.
+    failures = [c for c in summary["cases"] if not c["passed"] and c["verdict"] != "error"]
+    lines += ["", "### Routing failures", ""]
+    if not failures:
+        lines.append("None. Every graded prompt routed as expected.")
+    else:
+        lines += [
+            "| Case | Category | Expected | Observed | Verdict | Prompt |",
+            "| --- | --- | --- | --- | --- | --- |",
+        ]
+        for case in failures:
+            prompt = case["prompt"].replace("|", "\\|")
+            if len(prompt) > 110:
+                prompt = prompt[:110] + "..."
+            lines.append(
+                f"| `{case['id']}` | {case['category']} | {case['expect'] or '(no skill)'} | "
+                f"{case['observed'] or '(no skill)'} | {case['verdict']} | {prompt} |"
+            )
+
+    errored = [c for c in summary["cases"] if c["verdict"] == "error"]
+    if errored:
+        lines += [
+            "",
+            "### Errored cases (not graded)",
+            "",
+            "| Case | Stopped after | Error |",
+            "| --- | --- | --- |",
+        ]
+        for case in errored:
+            detail = (case["error"] or "unknown").replace("|", "\\|").replace("\n", " ")
+            lines.append(f"| `{case['id']}` | {case['stop_reason']} | {detail[:160]} |")
+
+    lines += [
+        "",
+        "<details><summary>All cases</summary>",
+        "",
+        "| Case | Expected | Observed | Verdict | Stopped after | Seconds |",
+        "| --- | --- | --- | --- | --- | --- |",
+    ]
+    for case in summary["cases"]:
+        lines.append(
+            f"| `{case['id']}` | {case['expect'] or '(no skill)'} | "
+            f"{case['observed'] or '(no skill)'} | {case['verdict']} | "
+            f"{case['stop_reason']} | {case['elapsed_s']} |"
+        )
+    lines += ["", "</details>"]
+
+    if totals["activations"] == 0 and totals["activations_expected"]:
+        lines += [
+            "",
+            "> **Not a valid result:** no skill activated in any case, including "
+            f"the {totals['activations_expected']} that expected one. The skills "
+            "were probably not installed for the session, or the activation "
+            "detector no longer matches this `claude` build. Re-run with "
+            "`--keep-logs` and inspect a transcript before trusting these numbers.",
+        ]
+    if summary["unexpected_skills"]:
+        lines += [
+            "",
+            f"> **Warning:** a skill outside the marketplace activated "
+            f"({', '.join(summary['unexpected_skills'])}). The runner has extra "
+            f"skills installed, so these routing results are not trustworthy.",
+        ]
+    if summary["skills_missing_from_session"]:
+        lines += [
+            "",
+            f"> **Warning:** the CLI did not report these marketplace skills at "
+            f"session init: {', '.join(summary['skills_missing_from_session'])}. "
+            f"They may not have been installed for the run.",
+        ]
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--model", default="opus", help="Model alias. CI pins this to opus. Default: opus.")
+    parser.add_argument("--effort", default="high", choices=["low", "medium", "high", "max"], help="Reasoning effort. Default: high.")
+    parser.add_argument("--prompts", default=str(PROMPTS_FILE), help="Path to the prompt set. Default: eval/routing/prompts.json.")
+    parser.add_argument("--only", default="", help="Comma-separated case ids or expected skill names to run.")
+    parser.add_argument("--jobs", type=int, default=4, help="Cases to run concurrently. Each gets its own workspace and session. Default: 4.")
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=240.0,
+        help=(
+            "Seconds before a case is abandoned. Generous because it only bites "
+            "when the agent neither activates a skill nor answers. Default: 240."
+        ),
+    )
+    parser.add_argument(
+        "--max-tool-calls",
+        type=int,
+        default=4,
+        help=(
+            "Stop a case after this many non-skill tool calls. Agents often look "
+            "around (ls, read a file) before invoking a skill, so this is not 1; "
+            "it is small enough to cut the run off long before real work starts. "
+            "Default: 4."
+        ),
+    )
+    parser.add_argument(
+        "--max-budget-usd",
+        type=float,
+        default=0.75,
+        help="Per-case spend cap enforced by the CLI, independent of the early stop. 0 disables. Default: 0.75.",
+    )
+    parser.add_argument("--output", default="", help="Write the JSON report here. Default: eval/runs/routing-<timestamp>.json.")
+    parser.add_argument("--summary", default="", help="Write the markdown report here (defaults to $GITHUB_STEP_SUMMARY when set).")
+    parser.add_argument("--keep-logs", default="", help="Directory for raw per-case stream-json transcripts.")
+    parser.add_argument("--min-accuracy", type=float, default=0.0, help="Exit non-zero when accuracy falls below this (0-1). Default: 0 (report only).")
+    parser.add_argument("--skip-preflight", action="store_true", help="Skip the API reachability check.")
+    args = parser.parse_args(argv)
+
+    args.model = enforce_model_policy(args.model)
+
+    skills = marketplace_skills()
+    cases = load_cases(Path(args.prompts))
+    if args.only:
+        wanted = {token.strip() for token in args.only.split(",") if token.strip()}
+        cases = [c for c in cases if c.id in wanted or (c.expect or "") in wanted]
+        if not cases:
+            raise SystemExit(f"error: --only '{args.only}' matched no cases")
+
+    args.available_flags = supported_flags(["--no-session-persistence", "--max-budget-usd"])
+
+    if not args.skip_preflight:
+        ok, detail = check_api_reachable(args.model)
+        if not ok:
+            raise SystemExit(f"error: claude API not reachable -- {detail}")
+
+    print(f"[routing] skills installed per case: {', '.join(skills)}")
+    print(f"[routing] {len(cases)} cases, model={args.model}, effort={args.effort}, jobs={args.jobs}")
+
+    started = time.time()
+    if args.jobs > 1 and len(cases) > 1:
+        with ThreadPoolExecutor(max_workers=args.jobs) as pool:
+            outcomes = list(pool.map(lambda c: run_case(c, skills, args), cases))
+    else:
+        outcomes = [run_case(case, skills, args) for case in cases]
+
+    meta = {
+        "model": args.model,
+        "effort": args.effort,
+        "skills": skills,
+        "prompts": str(Path(args.prompts).name),
+        "wall_time_s": round(time.time() - started, 1),
+        "max_tool_calls": args.max_tool_calls,
+        "max_budget_usd": args.max_budget_usd,
+        "optional_cli_flags_used": sorted(args.available_flags),
+        "github_run_id": os.environ.get("GITHUB_RUN_ID"),
+    }
+    summary = summarize(outcomes, skills, meta)
+    report = render_markdown(summary)
+
+    # eval/runs/ is already gitignored, and claude_eval.py writes there too.
+    output = (
+        Path(args.output)
+        if args.output
+        else EVAL_DIR / "runs" / f"routing-{time.strftime('%Y%m%d-%H%M%S')}.json"
+    )
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+
+    print()
+    print(report)
+    print(f"[routing] JSON report: {output}")
+
+    summary_path = args.summary or os.environ.get("GITHUB_STEP_SUMMARY", "")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as handle:
+            handle.write(report)
+
+    totals = summary["totals"]
+    if totals["graded"] == 0:
+        print("[routing] every case errored; treating the run as a failure.", file=sys.stderr)
+        return 1
+    if totals["activations"] == 0 and totals["activations_expected"]:
+        print(
+            "[routing] no skill activated in any case -- the skills were not "
+            "installed, or activation detection is broken. Failing rather than "
+            "reporting a 0% routing rate as if it were real.",
+            file=sys.stderr,
+        )
+        return 1
+    if args.min_accuracy > 0 and (totals["accuracy"] or 0) < args.min_accuracy:
+        print(
+            f"[routing] accuracy {totals['accuracy']} is below the "
+            f"--min-accuracy bar of {args.min_accuracy}.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/eval/routing/routing_eval.py
+++ b/eval/routing/routing_eval.py
@@ -24,8 +24,9 @@ neighbor.
 
 Cost control: each run is killed the moment the routing decision is observable
 -- the first skill activation, the final result event, or a small budget of
-non-skill tool calls -- so no case pays for the work the skill would have gone
-on to do. ``--max-budget-usd`` is a second, independent backstop.
+tool calls that are neither bookkeeping nor a survey of the installed catalog
+-- so no case pays for the work the skill would have gone on to do.
+``--max-budget-usd`` is a second, independent backstop.
 
 Usage::
 
@@ -82,6 +83,9 @@ BOOKKEEPING_TOOLS = {"todowrite", "todoread", "exitplanmode"}
 # builds routed skills through the slash-command tool.
 SKILL_TOOLS = {"skill", "slashcommand"}
 
+# Where the staged catalog lives, as it appears in a tool argument.
+CATALOG_DIR = ".claude/skills"
+
 VERDICTS = ("correct_trigger", "true_negative", "missed_trigger", "wrong_skill", "false_trigger", "error")
 PASSING_VERDICTS = {"correct_trigger", "true_negative"}
 
@@ -109,7 +113,9 @@ class Outcome:
     stop_reason: str
     elapsed_s: float
     tool_calls: int
+    inspection_calls: int = 0
     visible_skills: list[str] = field(default_factory=list)
+    extra_skills: list[str] = field(default_factory=list)
     error: str | None = None
 
 
@@ -209,11 +215,25 @@ def supported_flags(flags: list[str]) -> set[str]:
     return {flag for flag in flags if flag in text}
 
 
-def claude_env() -> dict[str, str]:
+def claude_env(config_dir: Path | None = None) -> dict[str, str]:
     """Environment for `claude` subprocesses (fail fast instead of retrying)."""
     env = dict(os.environ)
     env.setdefault("CLAUDE_CODE_MAX_RETRIES", "0")
+    if config_dir is not None:
+        env["CLAUDE_CONFIG_DIR"] = str(config_dir)
     return env
+
+
+def can_isolate_config() -> bool:
+    """Whether the runner's own ``~/.claude`` can be kept out of the session.
+
+    User-level skills are registered next to the staged ones and change every
+    routing decision, so the catalog has to be exactly what the marketplace
+    ships. Pointing the CLI at a throwaway config dir achieves that, but only
+    when auth comes from the environment -- if the login lives in the real
+    config dir, hiding it means no case even starts.
+    """
+    return bool(os.environ.get("ANTHROPIC_API_KEY", "").strip())
 
 
 def _iter_tool_uses(obj) -> list[tuple[str, str]]:
@@ -261,13 +281,31 @@ def _skill_from_body_path(text: str, skills: list[str]) -> str | None:
     body was loaded" from "this text happens to mention the skill". Two or
     more matches mean the text enumerates the catalog, which is a listing
     rather than a decision, so that is not an activation either.
+
+    Reading one ``SKILL.md`` is only evidence of activation on a build that
+    has no way to activate a skill except by reading it; see
+    ``detect_activation``.
     """
     haystack = text.lower().replace("\\\\", "/").replace("\\", "/")
     hits = [skill for skill in skills if f"skills/{skill.lower()}/skill.md" in haystack]
     return hits[0] if len(hits) == 1 else None
 
 
-def detect_activation(event: dict, skills: list[str]) -> str | None:
+def _is_catalog_inspection(tool_input: str, skills: list[str]) -> bool:
+    """True when a tool call is only looking at the installed skills tree.
+
+    Surveying the catalog is part of making the routing decision, not the
+    agent starting the work itself, so these calls must not spend the
+    non-skill tool budget: ending a run mid-survey scored deliberation as a
+    missed trigger.
+    """
+    haystack = tool_input.lower().replace("\\\\", "/").replace("\\", "/")
+    if CATALOG_DIR in haystack:
+        return True
+    return any(f"skills/{skill.lower()}/" in haystack for skill in skills)
+
+
+def detect_activation(event: dict, skills: list[str], allow_body_path: bool = True) -> str | None:
     """The skill this event activates, or None.
 
     Only the agent's own tool calls count. Tool *results* and assistant prose
@@ -278,6 +316,13 @@ def detect_activation(event: dict, skills: list[str]) -> str | None:
     a false trigger on unrelated prompts, and -- worse -- scored a correct
     trigger whenever an expected skill's prompt named a path that did not
     exist, hiding real misses behind the file hunt.
+
+    ``allow_body_path`` carries the same distinction for tool *inputs*. On a
+    build that exposes the ``Skill`` tool, an agent that opens a ``SKILL.md``
+    is reading the catalog to choose from it, so treating that read as an
+    activation just credits whichever skill the directory listing happened to
+    put first. The path fallback therefore stays off unless the session has no
+    skill tool at all, which is the only case it was written for.
 
     Returns ``"other:<name>"`` when a skill outside the marketplace fires --
     that is a contaminated runner, not a routing result, and the report should
@@ -305,14 +350,15 @@ def detect_activation(event: dict, skills: list[str]) -> str | None:
         # instead of going through the Skill tool. The call itself has to
         # target that skill's own SKILL.md; merely touching the skills
         # directory (`ls .claude/skills`) is not a routing decision.
-        hit = _skill_from_body_path(tool_input, skills)
-        if hit:
-            return hit
+        if allow_body_path:
+            hit = _skill_from_body_path(tool_input, skills)
+            if hit:
+                return hit
 
     # Some builds announce an activation as a system event instead of a tool
     # call. Same joined-path rule, and init is excluded because it enumerates
     # the whole catalog by design.
-    if event.get("type") == "system" and event.get("subtype") != "init":
+    if allow_body_path and event.get("type") == "system" and event.get("subtype") != "init":
         return _skill_from_body_path(json.dumps(event, ensure_ascii=False), skills)
     return None
 
@@ -336,6 +382,49 @@ def _init_skills(event: dict, skills: list[str]) -> list[str] | None:
             if hit and hit not in seen:
                 seen.append(hit)
     return seen
+
+
+def _init_tools(event: dict) -> set[str] | None:
+    """Tool names the CLI reported at session init, if this is that event.
+
+    Used to decide whether the SKILL.md-path fallback in ``detect_activation``
+    applies to this build. An init event without a tool list leaves the
+    fallback on, which is how older builds behaved.
+    """
+    if event.get("type") != "system" or event.get("subtype") != "init":
+        return None
+    tools = event.get("tools")
+    if not isinstance(tools, list):
+        return set()
+    return {str(tool).lower() for tool in tools}
+
+
+def _init_extra_skills(event: dict, skills: list[str]) -> list[str] | None:
+    """Skills the CLI reported at init that this eval did not install.
+
+    A user-level skill on the runner is registered alongside the staged
+    catalog and competes for every prompt, so the routing numbers describe a
+    catalog nobody ships. The ``other:`` check only notices such a skill when
+    it actually fires; this notices it being installed at all.
+    """
+    if event.get("type") != "system" or event.get("subtype") != "init":
+        return None
+    entries = event.get("skills")
+    if not isinstance(entries, list):
+        return []
+    known = {skill.lower() for skill in skills}
+    extra: list[str] = []
+    for entry in entries:
+        if isinstance(entry, str):
+            name = entry
+        elif isinstance(entry, dict):
+            name = str(entry.get("name") or "")
+        else:
+            continue
+        name = name.strip().lstrip("/")
+        if name and name.lower() not in known and name not in extra:
+            extra.append(name)
+    return extra
 
 
 def _pump(stream, sink: queue.Queue) -> None:
@@ -383,6 +472,11 @@ def run_case(case: Case, skills: list[str], args: argparse.Namespace) -> Outcome
         raise SystemExit("error: 'claude' CLI not found on PATH")
 
     workspace = stage_workspace(skills)
+    # Outside the workspace: the agent can list its own cwd, and a config dir
+    # sitting in there would be one more thing for it to find.
+    config_dir = (
+        Path(tempfile.mkdtemp(prefix="routing-config-")) if args.isolate_config else None
+    )
     cmd = [
         claude_bin,
         "-p",
@@ -412,8 +506,11 @@ def run_case(case: Case, skills: list[str], args: argparse.Namespace) -> Outcome
     events: list[dict] = []
     observed: str | None = None
     visible: list[str] = []
+    extra: list[str] = []
     stop_reason = "completed"
     tool_calls = 0
+    inspection_calls = 0
+    allow_body_path = True
     error: str | None = None
     stderr_lines: list[str] = []
 
@@ -428,7 +525,7 @@ def run_case(case: Case, skills: list[str], args: argparse.Namespace) -> Outcome
         encoding="utf-8",
         errors="replace",
         bufsize=1,
-        env=claude_env(),
+        env=claude_env(config_dir),
         **spawn,
     )
     try:
@@ -466,8 +563,14 @@ def run_case(case: Case, skills: list[str], args: argparse.Namespace) -> Outcome
             reported = _init_skills(event, skills)
             if reported is not None:
                 visible = reported
+            uninstalled = _init_extra_skills(event, skills)
+            if uninstalled is not None:
+                extra = uninstalled
+            tools = _init_tools(event)
+            if tools is not None:
+                allow_body_path = not (tools & SKILL_TOOLS)
 
-            hit = detect_activation(event, skills)
+            hit = detect_activation(event, skills, allow_body_path=allow_body_path)
             if hit:
                 observed = hit
                 stop_reason = "skill_activated"
@@ -479,12 +582,17 @@ def run_case(case: Case, skills: list[str], args: argparse.Namespace) -> Outcome
                     error = str(event.get("result") or "result event reported an error")[:400]
                 break
 
-            tool_calls += sum(
-                1
-                for name, _ in _iter_tool_uses(event)
-                if name.lower() not in BOOKKEEPING_TOOLS
-            )
-            if tool_calls >= args.max_tool_calls:
+            for name, tool_input in _iter_tool_uses(event):
+                if name.lower() in BOOKKEEPING_TOOLS:
+                    continue
+                if _is_catalog_inspection(tool_input, skills):
+                    inspection_calls += 1
+                else:
+                    tool_calls += 1
+            # Inspection is exempt from the tool budget but not unbounded: an
+            # agent that has read the whole catalog and still called no skill
+            # has made its decision, and the run should not idle to timeout.
+            if tool_calls >= args.max_tool_calls or inspection_calls >= args.max_inspection_calls:
                 stop_reason = "tool_budget"
                 break
     finally:
@@ -498,6 +606,8 @@ def run_case(case: Case, skills: list[str], args: argparse.Namespace) -> Outcome
                 encoding="utf-8",
             )
         shutil.rmtree(workspace, ignore_errors=True)
+        if config_dir is not None:
+            shutil.rmtree(config_dir, ignore_errors=True)
 
     if not events:
         error = ("".join(stderr_lines).strip() or "claude produced no stream-json output")[:400]
@@ -530,7 +640,9 @@ def run_case(case: Case, skills: list[str], args: argparse.Namespace) -> Outcome
         stop_reason=stop_reason,
         elapsed_s=round(elapsed, 2),
         tool_calls=tool_calls,
+        inspection_calls=inspection_calls,
         visible_skills=visible,
+        extra_skills=extra,
         error=error,
     )
     print(
@@ -600,6 +712,7 @@ def summarize(outcomes: list[Outcome], skills: list[str], meta: dict) -> dict:
             if skill not in o.visible_skills
         }
     )
+    catalog_extras = sorted({skill for o in outcomes for skill in o.extra_skills})
 
     return {
         "meta": meta,
@@ -622,6 +735,7 @@ def summarize(outcomes: list[Outcome], skills: list[str], meta: dict) -> dict:
         "confusion": {k: dict(v) for k, v in confusion.items()},
         "unexpected_skills": contaminated,
         "skills_missing_from_session": catalog_gaps,
+        "extra_skills_in_session": catalog_extras,
         "cases": [asdict(o) for o in outcomes],
     }
 
@@ -748,6 +862,20 @@ def render_markdown(summary: dict) -> str:
             f"session init: {', '.join(summary['skills_missing_from_session'])}. "
             f"They may not have been installed for the run.",
         ]
+    if summary["extra_skills_in_session"]:
+        extras = summary["extra_skills_in_session"]
+        shown = ", ".join(f"`{name}`" for name in extras[:12])
+        if len(extras) > 12:
+            shown += f", and {len(extras) - 12} more"
+        lines += [
+            "",
+            f"> **Warning:** {len(extras)} skill(s) beyond the marketplace catalog "
+            f"were registered for these sessions ({shown}). They come from the "
+            f"runner's own config (usually `~/.claude/skills`) and compete for "
+            f"every prompt, so the catalog measured here is not the one users "
+            f"install. Set `ANTHROPIC_API_KEY` so the run can use an isolated "
+            f"config dir, or remove them from the runner.",
+        ]
     return "\n".join(lines) + "\n"
 
 
@@ -779,6 +907,17 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--max-inspection-calls",
+        type=int,
+        default=8,
+        help=(
+            "Separate allowance for tool calls that only read the installed "
+            "skills tree. Surveying the catalog is part of the routing "
+            "decision, so it does not spend --max-tool-calls, but it is capped "
+            "so a run cannot idle to timeout. Default: 8."
+        ),
+    )
+    parser.add_argument(
         "--max-budget-usd",
         type=float,
         default=0.75,
@@ -802,6 +941,13 @@ def main(argv: list[str] | None = None) -> int:
             raise SystemExit(f"error: --only '{args.only}' matched no cases")
 
     args.available_flags = supported_flags(["--no-session-persistence", "--max-budget-usd"])
+    args.isolate_config = can_isolate_config()
+    if not args.isolate_config:
+        print(
+            "[routing] warning: ANTHROPIC_API_KEY is not set, so the runner's "
+            "own config dir is used and any user-level skill in it joins the "
+            "catalog for every case. The report flags what was registered.",
+        )
 
     if not args.skip_preflight:
         ok, detail = check_api_reachable(args.model)
@@ -825,6 +971,8 @@ def main(argv: list[str] | None = None) -> int:
         "prompts": str(Path(args.prompts).name),
         "wall_time_s": round(time.time() - started, 1),
         "max_tool_calls": args.max_tool_calls,
+        "max_inspection_calls": args.max_inspection_calls,
+        "isolated_config_dir": args.isolate_config,
         "max_budget_usd": args.max_budget_usd,
         "optional_cli_flags_used": sorted(args.available_flags),
         "github_run_id": os.environ.get("GITHUB_RUN_ID"),

--- a/skills/local-ai-app-integration/SKILL.md
+++ b/skills/local-ai-app-integration/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   text-to-speech to an existing app; replace or supplement OpenAI, Anthropic, Ollama, or
   other cloud AI APIs with a local backend; only use to convert user apps. Do not use when
   the user just wants the agent itself to generate images, transcribe, or speak locally in
-  the current workspace, even to cut their own API bill — that is local-ai-use.
+  the current workspace, even to cut their own API bill.
 ---
 
 # Local AI App Integration (Embeddable Lemonade)

--- a/skills/local-ai-app-integration/SKILL.md
+++ b/skills/local-ai-app-integration/SKILL.md
@@ -5,8 +5,9 @@ description: >-
   Use when the user wants to add local AI, offline AI, private AI, on-device AI,
   a local LLM, local chat, embeddings, image generation, speech-to-text, or
   text-to-speech to an existing app; replace or supplement OpenAI, Anthropic, Ollama, or
-  other cloud AI APIs with a local backend; only use to convert user apps; Do not use if
-  the goal is to simply run local ai tasks on a workspace instead of converting an app to use local ai.
+  other cloud AI APIs with a local backend; only use to convert user apps. Do not use when
+  the user just wants the agent itself to generate images, transcribe, or speak locally in
+  the current workspace, even to cut their own API bill — that is local-ai-use.
 ---
 
 # Local AI App Integration (Embeddable Lemonade)

--- a/skills/local-ai-app-integration/SKILL.md
+++ b/skills/local-ai-app-integration/SKILL.md
@@ -4,10 +4,9 @@ description: >-
   Integrates local AI capabilities into applications using Embeddable Lemonade.
   Use when the user wants to add local AI, offline AI, private AI, on-device AI,
   a local LLM, local chat, embeddings, image generation, speech-to-text, or
-  text-to-speech to an app; replace or supplement OpenAI, Anthropic, Ollama, or
-  other cloud AI APIs with a local backend; bundle AI inference into an app
-  installer; or mentions Lemonade, `lemond`, embeddable lemonade, Ryzen AI,
-  NPU/iGPU/dGPU inference, or auto-optimizing local AI.
+  text-to-speech to an existing app; replace or supplement OpenAI, Anthropic, Ollama, or
+  other cloud AI APIs with a local backend; only use to convert user apps; Do not use if
+  the goal is to simply run local ai tasks instead of converting an app to use local ai.
 ---
 
 # Local AI App Integration (Embeddable Lemonade)

--- a/skills/local-ai-app-integration/SKILL.md
+++ b/skills/local-ai-app-integration/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   a local LLM, local chat, embeddings, image generation, speech-to-text, or
   text-to-speech to an existing app; replace or supplement OpenAI, Anthropic, Ollama, or
   other cloud AI APIs with a local backend; only use to convert user apps; Do not use if
-  the goal is to simply run local ai tasks instead of converting an app to use local ai.
+  the goal is to simply run local ai tasks on a workspace instead of converting an app to use local ai.
 ---
 
 # Local AI App Integration (Embeddable Lemonade)

--- a/skills/local-ai-use/SKILL.md
+++ b/skills/local-ai-use/SKILL.md
@@ -2,7 +2,7 @@
 name: local-ai-use
 description: >-
   Use image generation, text-to-speech, and speech-to-text through a local
-  Lemonade Server so the agent stops paying for cloud calls on those modalities.
+  Lemonade Server on the current workspace so the agent stops paying for cloud calls.
   Use when the user wants to save tokens, save cost, or save money using local
   AI; default to local, offline, on-device, or private image generation,
   transcription, or text-to-speech in this workspace; stop using DALL-E,

--- a/skills/local-ai-use/SKILL.md
+++ b/skills/local-ai-use/SKILL.md
@@ -1,19 +1,19 @@
 ---
 name: local-ai-use
 description: >-
-  Generates images, transcribes audio, and synthesizes speech on the user's own
-  machine through a local Lemonade Server instead of a paid cloud API, for work
-  the agent itself does in the current workspace. Use for a one-off request —
-  transcribe this recording, make this picture, read this text aloud — whenever
-  the user wants it done locally, offline, on-device, or kept private, and also
-  when the user wants that routing to stick from now on. Use when the user wants
-  to save money, cost, or tokens on image, audio, or voice API calls; wants to
-  stop using DALL-E, Whisper-as-a-service, ElevenLabs, or other paid multimodal
-  APIs; says "use local models for pictures but keep the cloud for chat" in
-  Claude, Cursor, Codex, or another agent harness; or
-  mentions Lemonade Server, OmniRouter, SD-Turbo, kokoro, Whisper, Ryzen AI, or
-  NPU/iGPU/dGPU inference. Changes no application source code; do not use this 
-  skill if the user is instead adding local AI to an app they ship.
+  Makes this agent generate images, transcribe audio, and synthesize speech on
+  the user's own machine through a local Lemonade Server instead of a paid cloud
+  API. Use it above all to change that routing persistently, from now on — keep
+  generating pictures locally while chat stays on the cloud; set this workspace
+  up to make images on my own machine — even when the user asks for no image or
+  file in the same breath. Also use it for a single request the user wants done
+  locally, offline, on-device, or kept private: transcribe this recording, make
+  this picture, read this text aloud. Applies in Claude, Cursor, Codex, or any
+  agent harness. Use when the user wants to cut cost or tokens on image, audio,
+  or voice API calls, or to drop DALL-E, hosted Whisper, ElevenLabs, or other
+  paid multimodal APIs; or mentions Lemonade Server, OmniRouter, SD-Turbo,
+  kokoro, Ryzen AI, or NPU/iGPU/dGPU inference. Changes no application source
+  code; do not use it if the user is adding local AI to an app they ship.
 ---
 
 # Local AI Use (route image, TTS, STT through Lemonade)

--- a/skills/local-ai-use/SKILL.md
+++ b/skills/local-ai-use/SKILL.md
@@ -1,17 +1,19 @@
 ---
 name: local-ai-use
 description: >-
-  Use image generation, text-to-speech, and speech-to-text through a local
-  Lemonade Server on the current workspace so the agent stops paying for cloud calls.
-  Use when the user wants to save tokens, save cost, or save money using local
-  AI; default to local, offline, on-device, or private image generation,
-  transcription, or text-to-speech in this workspace; stop using DALL-E,
-  Whisper-as-a-service, ElevenLabs, or other paid multimodal APIs; route the
-  agent's image, TTS, or STT tool calls to a local model; or mentions Lemonade
-  Server, OmniRouter, SD-Turbo, kokoro, Whisper, Ryzen AI, NPU/iGPU/dGPU
-  inference, or "use local for images but cloud for chat". Run once per
-  workspace; the rule it installs handles every later request; use to setup local
-  use on claude, cursor, codex and other agentic harnesses.
+  Generates images, transcribes audio, and synthesizes speech on the user's own
+  machine through a local Lemonade Server instead of a paid cloud API, for work
+  the agent itself does in the current workspace. Use for a one-off request —
+  transcribe this recording, make this picture, read this text aloud — whenever
+  the user wants it done locally, offline, on-device, or kept private, and also
+  when the user wants that routing to stick from now on. Use when the user wants
+  to save money, cost, or tokens on image, audio, or voice API calls; wants to
+  stop using DALL-E, Whisper-as-a-service, ElevenLabs, or other paid multimodal
+  APIs; says "use local models for pictures but keep the cloud for chat" in
+  Claude, Cursor, Codex, or another agent harness; or
+  mentions Lemonade Server, OmniRouter, SD-Turbo, kokoro, Whisper, Ryzen AI, or
+  NPU/iGPU/dGPU inference. Changes no application source code; do not use this 
+  skill if the user is instead adding local AI to an app they ship.
 ---
 
 # Local AI Use (route image, TTS, STT through Lemonade)

--- a/skills/local-ai-use/SKILL.md
+++ b/skills/local-ai-use/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: local-ai-use
 description: >-
-  Routes image generation, text-to-speech, and speech-to-text through a local
+  Use image generation, text-to-speech, and speech-to-text through a local
   Lemonade Server so the agent stops paying for cloud calls on those modalities.
   Use when the user wants to save tokens, save cost, or save money using local
   AI; default to local, offline, on-device, or private image generation,
@@ -10,7 +10,8 @@ description: >-
   agent's image, TTS, or STT tool calls to a local model; or mentions Lemonade
   Server, OmniRouter, SD-Turbo, kokoro, Whisper, Ryzen AI, NPU/iGPU/dGPU
   inference, or "use local for images but cloud for chat". Run once per
-  workspace; the rule it installs handles every later request.
+  workspace; the rule it installs handles every later request; use to setup local
+  use on claude, cursor, codex and other agentic harnesses.
 ---
 
 # Local AI Use (route image, TTS, STT through Lemonade)


### PR DESCRIPTION
# Description

This PR:
* Creates a routing test to assess skill precision/recall
* Improves the description of local-ai-use and local-ai-app-integration.


## Sample Eval

**23/23 correct (100.0%)** across 23 prompts with 4 marketplace skills installed together, on `opus` (effort `high`).

| Verdict | Count | Meaning |
| --- | --- | --- |
| correct_trigger | 16 | expected skill activated |
| true_negative | 7 | no skill expected, none activated |
| missed_trigger | 0 | skill expected, nothing activated |
| wrong_skill | 0 | a skill activated, but the wrong one |
| false_trigger | 0 | no skill expected, one activated |
| error | 0 | the run failed; excluded from accuracy |

### By prompt category

| Category | Graded | Correct | Accuracy |
| --- | --- | --- | --- |
| near_miss | 4 | 4 | 100% |
| positive | 16 | 16 | 100% |
| unrelated | 3 | 3 | 100% |

### Per skill

| Skill | Expected | Correct | Missed | Lost to another skill | Fired when not expected | Recall | Precision |
| --- | --- | --- | --- | --- | --- | --- | --- |
| `local-ai-use` | 4 | 4 | 0 | 0 | 0 | 100% | 100% |
| `local-ai-app-integration` | 4 | 4 | 0 | 0 | 0 | 100% | 100% |
| `serving-llms-on-instinct` | 4 | 4 | 0 | 0 | 0 | 100% | 100% |
| `tracelens-analysis-orchestrator` | 4 | 4 | 0 | 0 | 0 | 100% | 100% |

### Routing failures

None. Every graded prompt routed as expected.

<details><summary>All cases</summary>

| Case | Expected | Observed | Verdict | Stopped after | Seconds |
| --- | --- | --- | --- | --- | --- |
| `images-cost` | local-ai-use | local-ai-use | correct_trigger | skill_activated | 4.59 |
| `tts-offline` | local-ai-use | local-ai-use | correct_trigger | skill_activated | 4.35 |
| `transcribe-private` | local-ai-use | local-ai-use | correct_trigger | skill_activated | 3.05 |
| `split-routing` | local-ai-use | local-ai-use | correct_trigger | skill_activated | 4.1 |
| `electron-offline-mode` | local-ai-app-integration | local-ai-app-integration | correct_trigger | skill_activated | 4.38 |
| `swap-anthropic-backend` | local-ai-app-integration | local-ai-app-integration | correct_trigger | skill_activated | 5.79 |
| `vendor-binary` | local-ai-app-integration | local-ai-app-integration | correct_trigger | skill_activated | 4.96 |
| `in-app-embeddings` | local-ai-app-integration | local-ai-app-integration | correct_trigger | skill_activated | 4.05 |
| `qwen-on-mi300x` | serving-llms-on-instinct | serving-llms-on-instinct | correct_trigger | skill_activated | 4.41 |
| `vllm-rocm-node` | serving-llms-on-instinct | serving-llms-on-instinct | correct_trigger | skill_activated | 6.4 |
| `openai-compatible-mi355x` | serving-llms-on-instinct | serving-llms-on-instinct | correct_trigger | skill_activated | 3.67 |
| `deploy-datacenter-gpu` | serving-llms-on-instinct | serving-llms-on-instinct | correct_trigger | skill_activated | 4.11 |
| `analyze-torch-trace` | tracelens-analysis-orchestrator | tracelens-analysis-orchestrator | correct_trigger | skill_activated | 6.29 |
| `compare-two-traces` | tracelens-analysis-orchestrator | tracelens-analysis-orchestrator | correct_trigger | skill_activated | 7.97 |
| `agentic-analysis-workflow` | tracelens-analysis-orchestrator | tracelens-analysis-orchestrator | correct_trigger | skill_activated | 3.98 |
| `kernel-perf-report` | tracelens-analysis-orchestrator | tracelens-analysis-orchestrator | correct_trigger | skill_activated | 4.99 |
| `vllm-on-nvidia` | (no skill) | (no skill) | true_negative | result | 33.47 |
| `consumer-radeon` | (no skill) | (no skill) | true_negative | result | 18.24 |
| `hbm-vs-gddr` | (no skill) | (no skill) | true_negative | result | 22.39 |
| `node-event-loop` | (no skill) | (no skill) | true_negative | result | 23.72 |
| `merge-sorted-lists` | (no skill) | (no skill) | true_negative | result | 16.62 |
| `windows-path-bug` | (no skill) | (no skill) | true_negative | result | 19.38 |
| `ruff-ci-job` | (no skill) | (no skill) | true_negative | result | 12.91 |

</details>
