### PR TITLE
Addressing feedback on `lemonade-router-builder`: More generalized examples

### DIFF
--- a/skills/lemonade-router-builder/SKILL.md
+++ b/skills/lemonade-router-builder/SKILL.md
@@ -23,7 +23,7 @@ try and stays editable in the desktop app's Hybrid Router editor.
 
 ## Prerequisites
 
-- **Lemonade Server v10.1.0+** running locally (`lemonade server start`).
+- **Lemonade Server v11.5.0+** running locally (`lemonade server start`).
   Required only to register and test the generated policy - the skill itself
   (JSON generation + offline validation) works without a live server.
 - **No GPU or ROCm dependency** for authoring. The router policy is a JSON
@@ -225,8 +225,8 @@ curl http://localhost:13305/api/v1/models/<model-id>
 curl -X POST http://localhost:13305/api/v1/pull \
      -H "Content-Type: application/json" --data-binary @router.json
 
-# 3. Route a request and inspect the decision
-curl -X POST http://localhost:13305/api/v1/chat/completions \
+# 3. Route a request and inspect the decision (-i prints response headers)
+curl -i -X POST http://localhost:13305/api/v1/chat/completions \
      -H "Content-Type: application/json" \
      -d '{"model": "<model_name>", "route_trace": true,
           "messages": [{"role": "user", "content": "<test prompt>"}]}'

--- a/walkthroughs/lemonade-router-builder.md
+++ b/walkthroughs/lemonade-router-builder.md
@@ -16,7 +16,7 @@ Install the **latest** Lemonade Server (**v11.5.0 or later**) from
 at least two chat-capable models:
 
 ```bash
-lemonade server start
+lemonade-server serve
 lemonade list
 ```
 

--- a/walkthroughs/lemonade-router-builder.md
+++ b/walkthroughs/lemonade-router-builder.md
@@ -18,6 +18,8 @@ lemonade server start
 lemonade list
 ```
 
+Note the exact model names shown by `lemonade list` - you will use them in the prompts below. The examples use `<LARGE_MODEL>` , `<CLOUD_MODEL>`, and`<SMALL_MODEL` as placeholders; substitute the names of your two installed models (e.g. Gemma-4-31B-it-GGUF for large, Gemma-3-4b-it-GGUF for small, and kimi-k2p6 for cloud).
+
 ## Step 2 - Confirm the skill is visible
 
 ```bash
@@ -36,7 +38,9 @@ Open Claude and run:
 
 ```
 Route coding questions - anything mentioning functions, bugs, or stack traces -
-to Qwen3.5-9B-GGUF. Everything else goes to Qwen3.5-2B-GGUF.
+to <LARGE_MODEL>. Everything else goes to <SMALL_MODEL>.
+
+Example: Route coding questions - anything mentioning functions, bugs, or stack traces - to Gemma-4-31B-it-GGUF. Everything else goes to Gemma-3-4b-it-GGUF.
 ```
 
 The agent should:
@@ -49,12 +53,15 @@ The agent should:
 
 ## Step 4 - Register and test the router yourself
 
-Copy the curl commands the agent produced and run them in your terminal:
+The agent will save the policy as `router.json`. Note the full path it reports,
+then run the curl commands **from the same directory** (or use the absolute path).
+The `@` prefix in `--data-binary` tells curl to read the body from a file; it
+resolves relative to your current working directory, not where the file was saved.
 
 ```bash
-# Register
+# Register (replace /path/to/ with wherever the agent saved router.json)
 curl -X POST http://localhost:13305/api/v1/pull \
-     -H "Content-Type: application/json" --data-binary @router.json
+     -H "Content-Type: application/json" --data-binary @/path/to/router.json
 
 # Test - should match the keyword rule
 curl -X POST http://localhost:13305/api/v1/chat/completions \
@@ -70,8 +77,9 @@ the full per-condition trace.
 ## Step 5 - Try a PII privacy router
 
 ```
-Any message containing a Social Security number or email address must stay on
-Qwen3.5-9B-GGUF. Everything else can go to Qwen3.5-9B-NoThinking.
+Any message containing a Social Security number or email address must stay on <SMALL_MODEL>. Everything else can go to <CLOUD_MODEL>.
+
+Example: Any message containing a Social Security number or email address must stay on Gemma-3-4b-it-GGUF. Everything else can go to fireworks.kimi-k2p6.
 ```
 
 The agent should produce a rules-mode policy with two `regex` conditions and
@@ -81,8 +89,9 @@ place the PII rule first. Validate by sending a test message with a fake SSN
 ## Step 6 - Try an LLM-as-router (intent-only)
 
 ```
-I want sensitive queries to stay on Qwen3.5-9B-GGUF and everything else to go
-to Qwen3.5-9B-NoThinking. Use the local model as the router.
+I want sensitive queries to stay on <LARGE_MODEL> and everything else to go to <CLOUD_MODEL>. Use the local model as the router.
+
+Example: I want sensitive queries to stay on Gemma-4-31B-it-GGUF and everything else to go to fireworks.kimi-k2p6. Use the local model as the router.
 ```
 
 The agent should choose Mode A (`routing.router` block) rather than rules,

--- a/walkthroughs/lemonade-router-builder.md
+++ b/walkthroughs/lemonade-router-builder.md
@@ -3,6 +3,7 @@
 The goal of this skill is to teach your AI agent to turn a plain-English
 description of routing intent into a valid Lemonade `collection.router` policy
 JSON, ready for you to register and use.
+[Documentation on Lemonade Router](https://lemonade-server.ai/docs/dev/router-policy/)
 
 ## Prerequisites
 
@@ -10,8 +11,9 @@ JSON, ready for you to register and use.
 
 ## Step 1 - Install and start Lemonade Server
 
-Install Lemonade Server from <https://lemonade-server.ai/docs/guide/install/>,
-then start it and download at least two chat-capable models:
+Install the **latest** Lemonade Server (**v11.5.0 or later**) from
+<https://lemonade-server.ai/docs/guide/install/>, then start it and download
+at least two chat-capable models:
 
 ```bash
 lemonade server start
@@ -63,8 +65,8 @@ resolves relative to your current working directory, not where the file was save
 curl -X POST http://localhost:13305/api/v1/pull \
      -H "Content-Type: application/json" --data-binary @/path/to/router.json
 
-# Test - should match the keyword rule
-curl -X POST http://localhost:13305/api/v1/chat/completions \
+# Test - Claude should give you the exact command; if not, adapt this one (update <RouterName> and "messages")
+curl -i -X POST http://localhost:13305/api/v1/chat/completions \
      -H "Content-Type: application/json" \
      -d '{"model": "user.<RouterName>", "route_trace": true,
           "messages": [{"role": "user", "content": "How do I fix this bug?"}]}'

--- a/walkthroughs/lemonade-router-builder.md
+++ b/walkthroughs/lemonade-router-builder.md
@@ -12,11 +12,10 @@ JSON, ready for you to register and use.
 ## Step 1 - Install and start Lemonade Server
 
 Install the **latest** Lemonade Server (**v11.5.0 or later**) from
-<https://lemonade-server.ai/docs/guide/install/>, then start it and download
+<https://lemonade-server.ai/docs/guide/install/>, and download
 at least two chat-capable models:
 
-```bash
-lemonade-server serve
+lemonade status
 lemonade list
 ```
 


### PR DESCRIPTION
Addressed feedback from the ROCm.AI Dogfooding Group. Generalized the examples by removing hardcoded model names