### PR TITLE
Addressing DogFooding experiences feedback

### DIFF
--- a/skills/lemonade-router-builder/SKILL.md
+++ b/skills/lemonade-router-builder/SKILL.md
@@ -47,6 +47,8 @@ exist, and choosing the right one is the first decision:
 - **Candidates**: the models that may *answer* requests. Verbatim model names
   (e.g. `Gemma-3-4b-it-GGUF`). If the user names none, ask - never invent
   model names. `lemonade list` or `GET /api/v1/models` shows what's available.
+  A name the user *did* give may still not exist on the target host - the
+  offline validator can't check that (Step 8b closes the gap).
 - **Default / fallback**: which candidate gets everything that matches nothing.
   If unstated, use the model the user framed as "local", "small", or "safe";
   otherwise the first candidate mentioned.
@@ -99,8 +101,18 @@ chat-capable LLMs - not embedding, classification, or image models.
 }
 ```
 
-- `model` defaults to the smallest candidate (it may be a candidate; it also
-  works as a separate small model).
+- `model` defaults to the **most capable candidate**, not the cheapest one.
+  The router judges every single request that flows through the policy, so a
+  weak judge silently misrouting everything is a worse default than the extra
+  cost of a stronger one. State the choice in the summary you give the user -
+  `router.model: <chosen>` (most capable candidate available; pick a smaller
+  dedicated judge model yourself for lower per-request cost, at the risk of
+  the failure mode below). If the user already named a separate model for
+  this role, use that instead of a candidate.
+- If `default_used` stays `true` across varied test prompts even after fixing
+  the prompt (see the bullet below and Step 9), the fix is a more capable
+  `router.model`, not a further prompt edit - this is a judge-model-capability
+  limit, not something prompt wording alone can solve.
 - **Write intent only - never specify a reply format and never use imperative
   "Pick X" phrasing.** The engine unconditionally appends its own contract
   after your prompt: it lists the candidate names and demands a strict JSON
@@ -142,8 +154,11 @@ Hard constraints (parser-enforced - see `reference.md` for the full matrix):
 
 - `classifier` type: model should be a text-classification model (an
   `onnxruntime` encoder like `Bert-Phishing-ONNX`); `labels` must match the
-  model's actual output labels. A chat LLM here is legal (LLM-as-classifier
-  via chat) but prefer `type: "llm"` for that - it is explicit and prompted.
+  model's actual output labels - unverifiable offline, and a mismatch
+  silently scores `0.0` forever (see `reference.md`'s classifier notes for
+  why, Step 8b for how to catch it). A chat LLM here is legal
+  (LLM-as-classifier via chat) but prefer `type: "llm"` for that - it is
+  explicit and prompted.
 - `semantic_similarity`: `reference_phrases` is `{concept: [phrases...]}`,
   at least one concept, each with at least one phrase. Concept names ARE the
   labels - a `labels` key is **rejected** for this type. Model must be an
@@ -155,7 +170,9 @@ Hard constraints (parser-enforced - see `reference.md` for the full matrix):
   "Reply with exactly one label: SAFE or RISKY" causes weaker models to output
   bare `SAFE`, which the parser rejects - the score comes back empty and the
   rule silently never fires. Describe what makes a request belong to each
-  label; leave the reply format to the engine.
+  label; leave the reply format to the engine. If it still never fires after
+  that, see Step 4's judge-capability note above - the same fix applies here
+  (Step 9 shows how to catch it).
 - `default_label`, when present, must be one of the labels/concepts.
 - Defaults when unspecified: `id` = `clf-1`, `clf-2`, …; `on_error` =
   `"match_false"` (fail-open: a broken classifier doesn't match, so requests
@@ -217,6 +234,11 @@ as plain text for the user to copy and run. This is not optional. Fill in
 that should hit the first rule. Do not execute these with Bash or any tool —
 print them as text only.
 
+`ready: true` from the validator only means the JSON is schema-valid - it
+says nothing about whether these models exist on the target host. Run #1 for
+every candidate/classifier model before #2, or `/pull` will 400 on a policy
+that just passed validation.
+
 ```bash
 # 1. Check a model exists before registering
 curl http://localhost:13305/api/v1/models/<model-id>
@@ -235,7 +257,36 @@ curl -i -X POST http://localhost:13305/api/v1/chat/completions \
 The `x-lemonade-route` response header carries the matched rule id (or
 `default`). With `"route_trace": true` the body also carries
 `x_lemonade_route`: `{ route_to, matched_rule, default_used, outputs,
-trace[] }` - useful for verifying each rule fires as expected.
+trace[] }`.
+
+## Step 9 - Print instructions for the user to verify routing themselves
+
+**This step is mandatory, not optional follow-up.** A policy that passed
+validation and registered cleanly can still send every request to the wrong
+model, or silently score `0.0` forever, with the server returning HTTP 200
+and no error either way - and neither failure is visible from the JSON or
+from Step 8a's validator. Per the skill's design, you never call the live
+server yourself; instead, print the following as text so the user can run it
+and read the result.
+
+Print **two** test curl commands (adapt Step 8b's command #3 for both), one
+phrased to clearly hit a specific rule (or Mode A intent), one phrased to hit
+nothing so it should land on `default_model`. Then print these reading
+instructions immediately after:
+
+- Tell the user to check `x_lemonade_route` in each response, not just the
+  HTTP status.
+- **Check `default_used`, not the rationale.** `"default_used": true` with
+  `"matched_rule": ""` is the fallback signature. An empty `rationale` alone
+  is *not* a fallback signal - a successful route to a non-first candidate
+  commonly returns one too.
+- **For classifier-backed rules, check the per-condition `score` in
+  `trace[]`.** A score stuck at `0.0` on the request designed to clearly hit
+  that label means the declared `labels` entry doesn't match the model's real
+  output categories (Step 5) - not that the input failed to match.
+- If either check fails, the fix is a more capable `router.model` for Mode A
+  misroutes, or a corrected `labels` entry for classifier mismatches - tell
+  the user to report the result back so you can revise and re-validate.
 
 ## Defaults summary
 
@@ -250,6 +301,7 @@ trace[] }` - useful for verifying each rule fires as expected.
 | `min_score` | `0.5` |
 | `outputs` | omit |
 | router prompt | intent only - no reply-format instruction (Step 4) |
+| `router.model` (Mode A) | most capable candidate, not the cheapest (Step 4) |
 
 Worked NL → JSON pairs live in `examples.md`; the full schema, parser error
 matrix, and model-capability table live in `reference.md`; the offline

--- a/skills/lemonade-router-builder/reference.md
+++ b/skills/lemonade-router-builder/reference.md
@@ -67,6 +67,16 @@ Notes:
   where "can't check" should route to the restricted/local path).
 - A label-less `classifier` entry is legal (single-score models); its rule
   leaves then must not name a `label`.
+- **`labels` on a `classifier` entry cannot be checked offline.**
+  `scripts/validate.py` only verifies internal consistency (rules reference
+  labels you declared) - it has no way to confirm those labels match the
+  model's real output categories, since that requires calling the live model.
+  A mismatched label doesn't error at registration or at request time; it
+  silently scores `0.0` on every request, and with the default
+  `on_error: match_false` the rule permanently falls through with no visible
+  error. Verify by sending a test prompt designed to clearly hit the label and
+  checking the trace `score` - stuck at `0.0` on an obvious match means the
+  label name is wrong, not that the input didn't match.
 - Scores are `{label: score}` with each score in `[0, 1]`.
 - **`llm` classifier wire contract** - the engine appends its own JSON reply
   contract after every `llm` classifier prompt, exactly as it does for
@@ -77,6 +87,8 @@ Notes:
   causes weaker models to output bare `X`, the parser rejects it, the score
   comes back empty, and the rule silently never fires. Describe classification
   intent only (what makes a request COMPLEX vs SIMPLE, SAFE vs RISKY, etc.).
+  If it still never fires after that, this is the same judge-capability limit
+  as `routing.router` (SKILL.md Step 4) - swap in a stronger model.
 
 ## Rules and match expressions
 
@@ -189,6 +201,16 @@ trace[] }` - use it to demonstrate each rule to the user. `version` is always
 for keyword/metadata conditions. Registration errors come back as descriptive
 parser messages (e.g. `routing.default_model 'X' must be listed in
 routing.candidates`); fix the field it names and re-POST.
+
+`default_used: true` + `matched_rule: ""` is the only reliable fallback
+signal - an empty `rationale` alone is not, since a successful Mode A route to
+a non-first candidate commonly returns one too. In Mode A, a non-fallback
+`matched_rule` is a synthetic id (`__route_0`, `__route_1`, … - one per
+`routing.candidates` entry, in declaration order), not an author-given one;
+seeing one of these is expected, not an error. For classifier-backed rules,
+also check the per-condition `score` in `trace[]` - stuck at `0.0` across
+clearly-matching test inputs signals a mismatched `labels` entry, not a
+non-match (see [Classifier entries](#classifier-entries)).
 
 ## Desktop-editor compatibility
 

--- a/walkthroughs/lemonade-router-builder.md
+++ b/walkthroughs/lemonade-router-builder.md
@@ -77,6 +77,8 @@ the full per-condition trace.
 
 ## Step 5 - Try a PII privacy router
 
+On a new Claude session, run:
+
 ```
 Any message containing a Social Security number or email address must stay on <SMALL_MODEL>. Everything else can go to <CLOUD_MODEL>.
 
@@ -85,9 +87,19 @@ Example: Any message containing a Social Security number or email address must s
 
 The agent should produce a rules-mode policy with two `regex` conditions and
 place the PII rule first. Validate by sending a test message with a fake SSN
-(`123-45-6789`) and confirming the header shows `pii-stays-local`.
+(`123-45-6789`) and confirming the header shows that rule's id - expect the
+default `rule-1` unless you asked the agent to name it something else.
+
+If Claude refuses to send a test message containing a fake SSN, drop the SSN
+condition and test with the email address only instead:
+
+```
+Any message containing an email address must stay on <SMALL_MODEL>. Everything else can go to <CLOUD_MODEL>.
+```
 
 ## Step 6 - Try an LLM-as-router (intent-only)
+
+On a new Claude session, run:
 
 ```
 I want sensitive queries to stay on <LARGE_MODEL> and everything else to go to <CLOUD_MODEL>. Use the local model as the router.


### PR DESCRIPTION
Thank you @amd-hasnasir and Matt for testing out the skill and sharing your valuable feedback. Addressed the pointers in this PR.

## Hasan's feedback
- SSN test prompt caused Claude to refuse → Since this is a model behavior and not consistently observed, added an alternative email-only backup command (Step 5). Fyi, the walkthroughs are only for internal devs so this would eventually become obsolete to the public.
- Steps 5/6 didn't say to use a new session → added "On a new Claude session, run:"
- Walkthrough expected rule id `pii-stays-local`, skill defaults to `rule-1` → fixed walkthrough to match actual default

## Matt's feedback
- "Write better prompts" doesn't fix silent misrouting - it's a judge-capability issue → `router.model` now defaults to most capable candidate, not cheapest. Also added a note to switch to smaller models if performance capacity is known
- Verification step was buried/undersold → promoted to mandatory Step 9
- Classifier label typos silently score 0 forever, no error → documented + added a verification check
- Validator can't confirm models exist on target host → noted in Step 1 / Step 8b
- Mode A trace ids are synthetic (`__route_0`, …), not author-given → documented in reference.md
- Empty `rationale` isn't a reliable fallback signal → clarified `default_used` is the real one
- GPU multi model resource gap → Lemonade allows loading >1 models depending on the GPU availability. However, clarifying that level of technicality is out of scope for this skill.
