### PR TITLE
Add Sphinx documentation set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ __pycache__/
 
 # Eval run artifacts (JSON reports and kept transcripts)
 eval/runs/
+
+# Sphinx docs: _toc.yml is generated from _toc.yml.in at build time
+docs/rocm-docs/sphinx/_toc.yml

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ AMD Skills provide agents with knowledge, scripts, and conventions for working w
 Skills in this repository follow the standardized [Agent Skills](https://github.com/anthropics/skills) format and are designed to interoperate with the major coding agents like Cursor, Claude Code, OpenAI Codex, and Gemini CLI.
 
 > [!IMPORTANT]
-> **Tech Preview:** We’re building the catalog in the open, sharing progress as the foundations take shape. Expect frequent changes as skills, categories, and descriptions evolve.
+> **Tech Preview:** This catalog is being built in the open, with progress shared as the foundations take shape. Expect frequent changes as skills, categories, and descriptions evolve.
 
 
 
@@ -47,7 +47,7 @@ Browse everything available before installing:
 npx skills add amd/skills --list
 ```
 
-Please note that `npx` requires [Node.js](https://nodejs.org). Prefer to do it by hand? See [Manual installation](#manual-installation).
+`npx` requires [Node.js](https://nodejs.org). Prefer to do it by hand? See [Manual installation](#manual-installation).
 
 ## Using a skill
 
@@ -64,7 +64,7 @@ For hands-on, step-by-step guides that show a skill in action, see the [walkthro
 
 The initial catalog is organized into three focus areas, spanning the full stack from client to cloud. This catalog is expected to grow significantly as more skills land.
 
-### Client-Native
+### Client-native
 
 Run and optimize on Ryzen AI.
 
@@ -73,7 +73,7 @@ Run and optimize on Ryzen AI.
 | [`local-ai-use`](https://github.com/amd/skills/blob/main/skills/local-ai-use/SKILL.md) | Route image generation, text-to-speech, and speech-to-text through a local AI server to reduce token cost. | in-repo |
 | [`local-ai-app-integration`](https://github.com/amd/skills/blob/main/skills/local-ai-app-integration/SKILL.md) | Integrate local AI into cloud LLM apps for offline support, better privacy, and lower API costs. | in-repo |
 
-### Cross-Stack
+### Cross-stack
 
 Cross-stack skills, from client to cloud.
 
@@ -84,7 +84,7 @@ Cross-stack skills, from client to cloud.
 | [`lemonade-router-builder`](https://github.com/amd/skills/blob/main/skills/lemonade-router-builder/SKILL.md) | Set up a Lemonade model router that handles requests based on content, sensitivity, or required capabilities. | in-repo |
 | `hrr-replay-analysis` | Record, replay, and analyze GPU workload behavior on ROCm across AMD Instinct, Radeon, and Ryzen hardware using HIP Record and Replay archives. | _planned_ |
 
-### Server-Native
+### Server-native
 
 Run and optimize on AMD Instinct.
 
@@ -119,7 +119,7 @@ Documentation describes an API surface: every flag, every option, neutral by des
 Skills earn their keep on repeated, opinionated workflows, exactly where the AMD stack lives.
 
 
-## Catalog Federation
+## Catalog federation
 
 The AMD stack is large and moves fast. ROCm, HIP, Ryzen AI, and framework integrations each have their own team, release cadence, and validation matrix. So skills here are **federated**: each skill is owned and versioned by the team that owns the product it describes, and this repository is the catalog that brings them together.
 
@@ -142,7 +142,7 @@ The AMD stack is large and moves fast. ROCm, HIP, Ryzen AI, and framework integr
    gfx-target-...  triton-amd-...  ...               integration/    repos
 ```
 
-## Manual Installation
+## Manual installation
 
 Until marketplace integration lands, install skills manually: clone this repo, then copy (or symlink) the skill folders you want from `skills/` into your agent's skills directory. Each agent discovers `SKILL.md` automatically.
 

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ Run and optimize on Ryzen AI.
 
 | Skill | What it does | Source |
 | --- | --- | --- |
-| [`local-ai-use`](skills/local-ai-use/SKILL.md) | Route image generation, text-to-speech, and speech-to-text through a local AI server to reduce token cost. | in-repo |
-| [`local-ai-app-integration`](skills/local-ai-app-integration/SKILL.md) | Integrate local AI into cloud LLM apps for offline support, better privacy, and lower API costs. | in-repo |
+| [`local-ai-use`](https://github.com/amd/skills/blob/main/skills/local-ai-use/SKILL.md) | Route image generation, text-to-speech, and speech-to-text through a local AI server to reduce token cost. | in-repo |
+| [`local-ai-app-integration`](https://github.com/amd/skills/blob/main/skills/local-ai-app-integration/SKILL.md) | Integrate local AI into cloud LLM apps for offline support, better privacy, and lower API costs. | in-repo |
 
 ### Cross-Stack
 
@@ -79,9 +79,9 @@ Cross-stack skills, from client to cloud.
 
 | Skill | What it does | Source |
 | --- | --- | --- |
-| [`rocm-doctor`](staging/rocm-doctor/SKILL.md) | Diagnose ROCm / HIP / PyTorch / llama.cpp failures on AMD GPUs (Linux and Windows) against a closed list of known misconfigurations, then fix with consent or route upstream. Thin driver over the `rocm` CLI (`examine` / `diagnose` / `fix`). | _planned_ |
+| [`rocm-doctor`](https://github.com/amd/skills/blob/main/staging/rocm-doctor/SKILL.md) | Diagnose ROCm / HIP / PyTorch / llama.cpp failures on AMD GPUs (Linux and Windows) against a closed list of known misconfigurations, then fix with consent or route upstream. Thin driver over the `rocm` CLI (`examine` / `diagnose` / `fix`). | _planned_ |
 | `hyperloom-workload-optimizer` | Autonomously optimizes LLM inference on AMD GPUs. | _planned_ |
-| [`lemonade-router-builder`](skills/lemonade-router-builder/SKILL.md) | Set up a Lemonade model router that handles requests based on content, sensitivity, or required capabilities. | in-repo |
+| [`lemonade-router-builder`](https://github.com/amd/skills/blob/main/skills/lemonade-router-builder/SKILL.md) | Set up a Lemonade model router that handles requests based on content, sensitivity, or required capabilities. | in-repo |
 | `hrr-replay-analysis` | Record, replay, and analyze GPU workload behavior on ROCm across AMD Instinct, Radeon, and Ryzen hardware using HIP Record and Replay archives. | _planned_ |
 
 ### Server-Native
@@ -90,10 +90,10 @@ Run and optimize on AMD Instinct.
 
 | Skill | What it does | Source |
 | --- | --- | --- |
-| [`serving-llms-on-instinct`](skills/serving-llms-on-instinct/SKILL.md) | Deploy LLM inference on AMD Instinct GPUs end-to-end: detect hardware (or onboard via AMD Developer Cloud), validate model fit, apply the right vLLM recipe, and launch a benchmarked endpoint. SGLang and engine/backend selection in later phases. | in-repo |
-| [`serving-llms-on-epyc`](skills/serving-llms-on-epyc/SKILL.md) | Serve LLMs on AMD EPYC CPUs with vLLM + zentorch, in a container (Docker/Podman) or conda. Handles CPU detection, runtime/env validation, vLLM model-support and RAM-fit checks, hardware-sized threads/KV, launch, and health verification. Single instance; reports and stops on failure. | in-repo |
-| [`magpie-kernel-evaluator`](skills/magpie-kernel-evaluator/SKILL.md) | Evaluate GPU kernel correctness and performance, compare kernel implementations, and benchmark vLLM / SGLang inference with profiling, TraceLens, and torch-trace gap analysis. | [Magpie](https://github.com/AMD-AGI/Magpie) |
-| [`tracelens-analysis-orchestrator`](skills/tracelens-analysis-orchestrator/SKILL.md) | Orchestrate modular PyTorch profiler trace analysis with TraceLens: generate perf reports, run system-level and compute-kernel subagents in parallel, and write a prioritized stakeholder report. | [TraceLens](https://github.com/AMD-AGI/TraceLens) |
+| [`serving-llms-on-instinct`](https://github.com/amd/skills/blob/main/skills/serving-llms-on-instinct/SKILL.md) | Deploy LLM inference on AMD Instinct GPUs end-to-end: detect hardware (or onboard via AMD Developer Cloud), validate model fit, apply the right vLLM recipe, and launch a benchmarked endpoint. SGLang and engine/backend selection in later phases. | in-repo |
+| [`serving-llms-on-epyc`](https://github.com/amd/skills/blob/main/skills/serving-llms-on-epyc/SKILL.md) | Serve LLMs on AMD EPYC CPUs with vLLM + zentorch, in a container (Docker/Podman) or conda. Handles CPU detection, runtime/env validation, vLLM model-support and RAM-fit checks, hardware-sized threads/KV, launch, and health verification. Single instance; reports and stops on failure. | in-repo |
+| [`magpie-kernel-evaluator`](https://github.com/amd/skills/blob/main/skills/magpie-kernel-evaluator/SKILL.md) | Evaluate GPU kernel correctness and performance, compare kernel implementations, and benchmark vLLM / SGLang inference with profiling, TraceLens, and torch-trace gap analysis. | [Magpie](https://github.com/AMD-AGI/Magpie) |
+| [`tracelens-analysis-orchestrator`](https://github.com/amd/skills/blob/main/skills/tracelens-analysis-orchestrator/SKILL.md) | Orchestrate modular PyTorch profiler trace analysis with TraceLens: generate perf reports, run system-level and compute-kernel subagents in parallel, and write a prioritized stakeholder report. | [TraceLens](https://github.com/AMD-AGI/TraceLens) |
 
 ## What is a skill?
 
@@ -110,7 +110,7 @@ skills/
 
 When an agent decides a skill is relevant (or you invoke it explicitly), it loads that `SKILL.md` and follows the instructions inside. Descriptions stay in context cheaply; the full body of a skill only loads when the task actually matches.
 
-Every skill also ships a `skill-card.md`: a short, human-facing governance card (Description, Owner, License) that tells a reviewer what the skill is and who stands behind it without reading the source. See [docs/skill-requirements.md](docs/skill-requirements.md#skill-cardmd).
+Every skill also ships a `skill-card.md`: a short, human-facing governance card (Description, Owner, License) that tells a reviewer what the skill is and who stands behind it without reading the source. See [docs/skill-requirements.md](https://github.com/amd/skills/blob/main/docs/skill-requirements.md#skill-cardmd).
 
 ## Why a skill, not a doc?
 
@@ -168,6 +168,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the step-by-step instructions, then
 
 ## License
 
-Released under the MIT License. See [LICENSE](LICENSE) for details.
+Released under the MIT License. See [LICENSE](https://github.com/amd/skills/blob/main/LICENSE) for details.
 
-Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved. 
+Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.

--- a/docs/rocm-docs/catalog.md
+++ b/docs/rocm-docs/catalog.md
@@ -1,0 +1,6 @@
+# Catalog
+
+```{include} ../../README.md
+:start-after: "## The catalog"
+:end-before: "## What is a skill?"
+```

--- a/docs/rocm-docs/catalog.md
+++ b/docs/rocm-docs/catalog.md
@@ -1,4 +1,4 @@
-# Catalog
+# Skills catalog
 
 ```{include} ../../README.md
 :start-after: "## The catalog"

--- a/docs/rocm-docs/concepts/index.md
+++ b/docs/rocm-docs/concepts/index.md
@@ -1,0 +1,22 @@
+# What is a Skill?
+
+```{include} ../../../README.md
+:start-after: "## What is a skill?"
+:end-before: "Every skill also ships a `skill-card.md`"
+```
+
+Every skill also ships a `skill-card.md`: a short, human-facing governance
+card (Description, Owner, License) that tells a reviewer what the skill is
+and who stands behind it without reading the source. See
+[skill-requirements.md](https://github.com/amd/skills/blob/main/docs/skill-requirements.md#skill-cardmd).
+
+```{include} ../../../README.md
+:start-after: "docs/skill-requirements.md#skill-cardmd)."
+:end-before: "## Manual Installation"
+```
+
+```{tip}
+See the [full catalog](https://github.com/amd/skills#the-catalog) in the
+`amd/skills` repository for the current list of available and planned
+skills.
+```

--- a/docs/rocm-docs/concepts/index.md
+++ b/docs/rocm-docs/concepts/index.md
@@ -2,21 +2,8 @@
 
 ```{include} ../../../README.md
 :start-after: "## What is a skill?"
-:end-before: "Every skill also ships a `skill-card.md`"
-```
-
-Every skill also ships a `skill-card.md`: a short, human-facing governance
-card (Description, Owner, License) that tells a reviewer what the skill is
-and who stands behind it without reading the source. See
-[skill-requirements.md](https://github.com/amd/skills/blob/main/docs/skill-requirements.md#skill-cardmd).
-
-```{include} ../../../README.md
-:start-after: "docs/skill-requirements.md#skill-cardmd)."
 :end-before: "## Manual Installation"
 ```
 
-```{tip}
-See the [full catalog](https://github.com/amd/skills#the-catalog) in the
-`amd/skills` repository for the current list of available and planned
-skills.
-```
+See the {doc}`full catalog <../catalog>` for the current list of available
+and planned skills.

--- a/docs/rocm-docs/concepts/index.md
+++ b/docs/rocm-docs/concepts/index.md
@@ -1,8 +1,8 @@
-# What is a Skill?
+# What is a skill?
 
 ```{include} ../../../README.md
 :start-after: "## What is a skill?"
-:end-before: "## Manual Installation"
+:end-before: "## Manual installation"
 ```
 
 See the {doc}`full catalog <../catalog>` for the current list of available

--- a/docs/rocm-docs/conf.py
+++ b/docs/rocm-docs/conf.py
@@ -1,0 +1,31 @@
+# Configuration file for the Sphinx documentation builder.
+# pylint: disable=invalid-name
+
+# -- Project information ---------------------------------------------------
+
+project = "AMD Skills"
+author = "Advanced Micro Devices, Inc."
+# pylint: disable=redefined-builtin
+copyright = "Copyright (c) Advanced Micro Devices, Inc. All rights reserved."
+# pylint: enable=redefined-builtin
+
+# -- General configuration -------------------------------------------------
+
+html_theme = "rocm_docs_theme"
+html_theme_options = {"flavor": "rocm"}
+html_title = "AMD Skills documentation"
+suppress_warnings = ["etoc.toctree"]
+external_toc_path = "./sphinx/_toc.yml"
+external_projects_current_project = "amd-skills"
+extensions = [
+    "rocm_docs",
+    "sphinx_design",
+]
+exclude_patterns = []
+
+# -- Sphinx setup ----------------------------------------------------------
+
+
+def setup(app):
+    """Sphinx setup"""
+    return {"parallel_read_safe": True, "parallel_write_safe": True}

--- a/docs/rocm-docs/index.rst
+++ b/docs/rocm-docs/index.rst
@@ -1,0 +1,46 @@
+.. meta::
+   :description: AMD Skills documentation.
+   :keywords: AMD Skills, AMD, ROCm, GPU
+
+========================
+AMD Skills documentation
+========================
+
+AMD Skills provide agents with knowledge, scripts, and conventions for
+working with AMD hardware and software.
+
+Skills in this repository follow the standardized
+`Agent Skills <https://github.com/anthropics/skills>`_ format and are
+designed to interoperate with the major coding agents like Cursor,
+Claude Code, OpenAI Codex, and Gemini CLI.
+
+.. important::
+
+   **Tech Preview:** We're building the catalog in the open, sharing progress
+   as the foundations take shape. Expect frequent changes as skills,
+   categories, and descriptions evolve.
+
+The AMD Skills public repository is located at
+`amd/skills <https://github.com/amd/skills>`_.
+
+.. grid:: 2
+   :gutter: 3
+
+   .. grid-item-card:: Catalog
+      :link: https://github.com/amd/skills#the-catalog
+      :link-type: url
+
+      Browse the `full catalog <https://github.com/amd/skills#the-catalog>`_
+      of available and planned skills.
+
+   .. grid-item-card:: Install
+
+      * :doc:`Installing AMD Skills <install/installation>`
+
+   .. grid-item-card:: What is a Skill?
+
+      * :doc:`What is a Skill? <concepts/index>`
+
+   .. grid-item-card:: Walkthroughs
+
+      * :doc:`Walkthroughs <walkthroughs/index>`

--- a/docs/rocm-docs/index.rst
+++ b/docs/rocm-docs/index.rst
@@ -16,8 +16,8 @@ Claude Code, OpenAI Codex, and Gemini CLI.
 
 .. important::
 
-   **Tech Preview:** We're building the catalog in the open, sharing progress
-   as the foundations take shape. Expect frequent changes as skills,
+   **Tech Preview:** This catalog is being built in the open, with progress
+   shared as the foundations take shape. Expect frequent changes as skills,
    categories, and descriptions evolve.
 
 The AMD Skills public repository is located at
@@ -26,18 +26,18 @@ The AMD Skills public repository is located at
 .. grid:: 2
    :gutter: 3
 
-   .. grid-item-card:: Catalog
-
-      * :doc:`Catalog <catalog>`
-
    .. grid-item-card:: Install
 
       * :doc:`Installing AMD Skills <install/installation>`
 
-   .. grid-item-card:: What is a Skill?
+   .. grid-item-card:: Conceptual
 
-      * :doc:`What is a Skill? <concepts/index>`
+      * :doc:`What is a skill? <concepts/index>`
 
    .. grid-item-card:: Walkthroughs
 
-      * :doc:`Walkthroughs <walkthroughs/index>`
+      * :doc:`All walkthroughs <walkthroughs/index>`
+
+   .. grid-item-card:: Catalog
+
+      * :doc:`Skills catalog <catalog>`

--- a/docs/rocm-docs/index.rst
+++ b/docs/rocm-docs/index.rst
@@ -27,11 +27,8 @@ The AMD Skills public repository is located at
    :gutter: 3
 
    .. grid-item-card:: Catalog
-      :link: https://github.com/amd/skills#the-catalog
-      :link-type: url
 
-      Browse the `full catalog <https://github.com/amd/skills#the-catalog>`_
-      of available and planned skills.
+      * :doc:`Catalog <catalog>`
 
    .. grid-item-card:: Install
 

--- a/docs/rocm-docs/install/installation.md
+++ b/docs/rocm-docs/install/installation.md
@@ -11,6 +11,6 @@ For hands-on, step-by-step guides that show a skill in action, see the
 ## Manual installation
 
 ```{include} ../../../README.md
-:start-after: "## Manual Installation"
+:start-after: "## Manual installation"
 :end-before: "## Contributing"
 ```

--- a/docs/rocm-docs/install/installation.md
+++ b/docs/rocm-docs/install/installation.md
@@ -1,0 +1,16 @@
+# Installing AMD Skills
+
+```{include} ../../../README.md
+:start-after: "## Installation"
+:end-before: "For hands-on, step-by-step guides that show a skill in action"
+```
+
+For hands-on, step-by-step guides that show a skill in action, see the
+[walkthroughs](../walkthroughs/index.md).
+
+## Manual installation
+
+```{include} ../../../README.md
+:start-after: "## Manual Installation"
+:end-before: "## Contributing"
+```

--- a/docs/rocm-docs/license.md
+++ b/docs/rocm-docs/license.md
@@ -1,0 +1,5 @@
+# License
+
+```{include} ../../README.md
+:start-after: "## License"
+```

--- a/docs/rocm-docs/license.rst
+++ b/docs/rocm-docs/license.rst
@@ -1,7 +1,0 @@
-=======
-License
-=======
-
-AMD Skills is distributed under the MIT License. See the
-`LICENSE <https://github.com/amd/skills/blob/main/LICENSE>`_ file in the
-repository for the full text.

--- a/docs/rocm-docs/license.rst
+++ b/docs/rocm-docs/license.rst
@@ -1,0 +1,7 @@
+=======
+License
+=======
+
+AMD Skills is distributed under the MIT License. See the
+`LICENSE <https://github.com/amd/skills/blob/main/LICENSE>`_ file in the
+repository for the full text.

--- a/docs/rocm-docs/sphinx/_toc.yml.in
+++ b/docs/rocm-docs/sphinx/_toc.yml.in
@@ -1,17 +1,26 @@
 root: index
 subtrees:
-  - caption: What is a Skill?
+  - caption: Catalog
     entries:
-      - file: concepts/index
+      - file: catalog
   - caption: Install
     entries:
       - file: install/installation
+  - caption: What is a Skill?
+    entries:
+      - file: concepts/index
   - caption: Walkthroughs
     entries:
       - file: walkthroughs/index
         subtrees:
           - entries:
               - file: walkthroughs/lemonade-router-builder
+              - file: walkthroughs/hyperloom-workload-optimizer
+              - file: walkthroughs/local-ai-app-integration
+              - file: walkthroughs/local-ai-use
+              - file: walkthroughs/magpie-kernel-evaluator
+              - file: walkthroughs/serving-llms-on-epyc
+              - file: walkthroughs/tracelens-analysis-orchestrator
   - caption: License
     entries:
       - file: license

--- a/docs/rocm-docs/sphinx/_toc.yml.in
+++ b/docs/rocm-docs/sphinx/_toc.yml.in
@@ -1,12 +1,9 @@
 root: index
 subtrees:
-  - caption: Catalog
-    entries:
-      - file: catalog
   - caption: Install
     entries:
       - file: install/installation
-  - caption: What is a Skill?
+  - caption: Conceptual
     entries:
       - file: concepts/index
   - caption: Walkthroughs
@@ -21,6 +18,9 @@ subtrees:
               - file: walkthroughs/magpie-kernel-evaluator
               - file: walkthroughs/serving-llms-on-epyc
               - file: walkthroughs/tracelens-analysis-orchestrator
-  - caption: License
+  - caption: Reference
+    entries:
+      - file: catalog
+  - caption: About
     entries:
       - file: license

--- a/docs/rocm-docs/sphinx/_toc.yml.in
+++ b/docs/rocm-docs/sphinx/_toc.yml.in
@@ -1,0 +1,17 @@
+root: index
+subtrees:
+  - caption: What is a Skill?
+    entries:
+      - file: concepts/index
+  - caption: Install
+    entries:
+      - file: install/installation
+  - caption: Walkthroughs
+    entries:
+      - file: walkthroughs/index
+        subtrees:
+          - entries:
+              - file: walkthroughs/lemonade-router-builder
+  - caption: License
+    entries:
+      - file: license

--- a/docs/rocm-docs/sphinx/requirements.txt
+++ b/docs/rocm-docs/sphinx/requirements.txt
@@ -1,0 +1,1 @@
+rocm-docs-core>=1.7.1

--- a/docs/rocm-docs/walkthroughs/hyperloom-workload-optimizer.md
+++ b/docs/rocm-docs/walkthroughs/hyperloom-workload-optimizer.md
@@ -1,2 +1,5 @@
+# hyperloom-workload-optimizer
+
 ```{include} ../../../walkthroughs/hyperloom-workload-optimizer.md
+:start-after: "# AMD Skills Walkthroughs: `hyperloom-workload-optimizer`"
 ```

--- a/docs/rocm-docs/walkthroughs/hyperloom-workload-optimizer.md
+++ b/docs/rocm-docs/walkthroughs/hyperloom-workload-optimizer.md
@@ -1,0 +1,2 @@
+```{include} ../../../walkthroughs/hyperloom-workload-optimizer.md
+```

--- a/docs/rocm-docs/walkthroughs/index.md
+++ b/docs/rocm-docs/walkthroughs/index.md
@@ -8,9 +8,9 @@
 Please choose a skill to get started.
 
 - [lemonade-router-builder](lemonade-router-builder.md): Generate a valid Lemonade router policy JSON from a plain-English description of routing intent.
-- [local-ai-use](https://github.com/amd/skills/blob/main/walkthroughs/local-ai-use.md): Teach your agent how to run image generation locally.
-- [local-ai-app-integration](https://github.com/amd/skills/blob/main/walkthroughs/local-ai-app-integration.md): Add a local AI mode to a cloud-only app.
-- [hyperloom-workload-optimizer](https://github.com/amd/skills/blob/main/walkthroughs/hyperloom-workload-optimizer.md): Set up Hyperloom and autonomously optimize LLM inference throughput on AMD Instinct GPUs.
-- [magpie-kernel-evaluator](https://github.com/amd/skills/blob/main/walkthroughs/magpie-kernel-evaluator.md): Benchmark inference, identify bottlenecks, and analyze, compare, and revalidate optimized GPU kernels with Magpie.
-- [serving-llms-on-epyc](https://github.com/amd/skills/blob/main/walkthroughs/serving-llms-on-epyc.md): Bring up a vLLM + zentorch LLM endpoint on an AMD EPYC™ CPU.
-- [tracelens-analysis-orchestrator](https://github.com/amd/skills/blob/main/walkthroughs/tracelens-analysis-orchestrator.md): Run agentic PyTorch profiler trace analysis and produce a prioritized performance report.
+- [local-ai-use](local-ai-use.md): Teach your agent how to run image generation locally.
+- [local-ai-app-integration](local-ai-app-integration.md): Add a local AI mode to a cloud-only app.
+- [hyperloom-workload-optimizer](hyperloom-workload-optimizer.md): Set up Hyperloom and autonomously optimize LLM inference throughput on AMD Instinct GPUs.
+- [magpie-kernel-evaluator](magpie-kernel-evaluator.md): Benchmark inference, identify bottlenecks, and analyze, compare, and revalidate optimized GPU kernels with Magpie.
+- [serving-llms-on-epyc](serving-llms-on-epyc.md): Bring up a vLLM + zentorch LLM endpoint on an AMD EPYC™ CPU.
+- [tracelens-analysis-orchestrator](tracelens-analysis-orchestrator.md): Run agentic PyTorch profiler trace analysis and produce a prioritized performance report.

--- a/docs/rocm-docs/walkthroughs/index.md
+++ b/docs/rocm-docs/walkthroughs/index.md
@@ -1,0 +1,16 @@
+# AMD Skills Walkthroughs
+
+```{include} ../../../walkthroughs/README.md
+:start-after: "## Requirements"
+:end-before: "Please choose a skill to get started."
+```
+
+Please choose a skill to get started.
+
+- [lemonade-router-builder](lemonade-router-builder.md): Generate a valid Lemonade router policy JSON from a plain-English description of routing intent.
+- [local-ai-use](https://github.com/amd/skills/blob/main/walkthroughs/local-ai-use.md): Teach your agent how to run image generation locally.
+- [local-ai-app-integration](https://github.com/amd/skills/blob/main/walkthroughs/local-ai-app-integration.md): Add a local AI mode to a cloud-only app.
+- [hyperloom-workload-optimizer](https://github.com/amd/skills/blob/main/walkthroughs/hyperloom-workload-optimizer.md): Set up Hyperloom and autonomously optimize LLM inference throughput on AMD Instinct GPUs.
+- [magpie-kernel-evaluator](https://github.com/amd/skills/blob/main/walkthroughs/magpie-kernel-evaluator.md): Benchmark inference, identify bottlenecks, and analyze, compare, and revalidate optimized GPU kernels with Magpie.
+- [serving-llms-on-epyc](https://github.com/amd/skills/blob/main/walkthroughs/serving-llms-on-epyc.md): Bring up a vLLM + zentorch LLM endpoint on an AMD EPYC™ CPU.
+- [tracelens-analysis-orchestrator](https://github.com/amd/skills/blob/main/walkthroughs/tracelens-analysis-orchestrator.md): Run agentic PyTorch profiler trace analysis and produce a prioritized performance report.

--- a/docs/rocm-docs/walkthroughs/index.md
+++ b/docs/rocm-docs/walkthroughs/index.md
@@ -1,11 +1,11 @@
-# AMD Skills Walkthroughs
+# AMD Skills walkthroughs
 
 ```{include} ../../../walkthroughs/README.md
 :start-after: "## Requirements"
-:end-before: "Please choose a skill to get started."
+:end-before: "Choose a skill to get started."
 ```
 
-Please choose a skill to get started.
+Choose a skill to get started.
 
 - [lemonade-router-builder](lemonade-router-builder.md): Generate a valid Lemonade router policy JSON from a plain-English description of routing intent.
 - [local-ai-use](local-ai-use.md): Teach your agent how to run image generation locally.

--- a/docs/rocm-docs/walkthroughs/lemonade-router-builder.md
+++ b/docs/rocm-docs/walkthroughs/lemonade-router-builder.md
@@ -1,0 +1,2 @@
+```{include} ../../../walkthroughs/lemonade-router-builder.md
+```

--- a/docs/rocm-docs/walkthroughs/lemonade-router-builder.md
+++ b/docs/rocm-docs/walkthroughs/lemonade-router-builder.md
@@ -1,2 +1,5 @@
+# lemonade-router-builder
+
 ```{include} ../../../walkthroughs/lemonade-router-builder.md
+:start-after: "# AMD Skills Walkthroughs: `lemonade-router-builder`"
 ```

--- a/docs/rocm-docs/walkthroughs/local-ai-app-integration.md
+++ b/docs/rocm-docs/walkthroughs/local-ai-app-integration.md
@@ -1,0 +1,2 @@
+```{include} ../../../walkthroughs/local-ai-app-integration.md
+```

--- a/docs/rocm-docs/walkthroughs/local-ai-app-integration.md
+++ b/docs/rocm-docs/walkthroughs/local-ai-app-integration.md
@@ -1,2 +1,5 @@
+# local-ai-app-integration
+
 ```{include} ../../../walkthroughs/local-ai-app-integration.md
+:start-after: "# AMD Skills Walkthroughs: `local-ai-app-integration`"
 ```

--- a/docs/rocm-docs/walkthroughs/local-ai-use.md
+++ b/docs/rocm-docs/walkthroughs/local-ai-use.md
@@ -1,2 +1,5 @@
+# local-ai-use
+
 ```{include} ../../../walkthroughs/local-ai-use.md
+:start-after: "# AMD Skills Walkthroughs: `local-ai-use`"
 ```

--- a/docs/rocm-docs/walkthroughs/local-ai-use.md
+++ b/docs/rocm-docs/walkthroughs/local-ai-use.md
@@ -1,0 +1,2 @@
+```{include} ../../../walkthroughs/local-ai-use.md
+```

--- a/docs/rocm-docs/walkthroughs/magpie-kernel-evaluator.md
+++ b/docs/rocm-docs/walkthroughs/magpie-kernel-evaluator.md
@@ -1,0 +1,2 @@
+```{include} ../../../walkthroughs/magpie-kernel-evaluator.md
+```

--- a/docs/rocm-docs/walkthroughs/magpie-kernel-evaluator.md
+++ b/docs/rocm-docs/walkthroughs/magpie-kernel-evaluator.md
@@ -1,2 +1,5 @@
+# magpie-kernel-evaluator
+
 ```{include} ../../../walkthroughs/magpie-kernel-evaluator.md
+:start-after: "# AMD Skills Walkthroughs: `magpie-kernel-evaluator`"
 ```

--- a/docs/rocm-docs/walkthroughs/serving-llms-on-epyc.md
+++ b/docs/rocm-docs/walkthroughs/serving-llms-on-epyc.md
@@ -1,0 +1,2 @@
+```{include} ../../../walkthroughs/serving-llms-on-epyc.md
+```

--- a/docs/rocm-docs/walkthroughs/serving-llms-on-epyc.md
+++ b/docs/rocm-docs/walkthroughs/serving-llms-on-epyc.md
@@ -1,2 +1,5 @@
+# serving-llms-on-epyc
+
 ```{include} ../../../walkthroughs/serving-llms-on-epyc.md
+:start-after: "# AMD Skills Walkthroughs: `serving-llms-on-epyc`"
 ```

--- a/docs/rocm-docs/walkthroughs/tracelens-analysis-orchestrator.md
+++ b/docs/rocm-docs/walkthroughs/tracelens-analysis-orchestrator.md
@@ -1,0 +1,2 @@
+```{include} ../../../walkthroughs/tracelens-analysis-orchestrator.md
+```

--- a/docs/rocm-docs/walkthroughs/tracelens-analysis-orchestrator.md
+++ b/docs/rocm-docs/walkthroughs/tracelens-analysis-orchestrator.md
@@ -1,2 +1,5 @@
+# tracelens-analysis-orchestrator
+
 ```{include} ../../../walkthroughs/tracelens-analysis-orchestrator.md
+:start-after: "# AMD Skills Walkthroughs: `tracelens-analysis-orchestrator`"
 ```

--- a/walkthroughs/README.md
+++ b/walkthroughs/README.md
@@ -4,9 +4,9 @@
 
 This collection of walkthroughs assumes you already have `claude code` setup on your machine.
 
-Participants using other agents are still encouraged to participate. Just please note that you may have to adapt some of the instructions provided below to your specific agent.
+Participants using other agents are still encouraged to participate. You might have to adapt some of the instructions provided below to your specific agent.
 
-Please choose a skill to get started.
+Choose a skill to get started.
 
 * [lemonade-router-builder](./lemonade-router-builder.md): Generate a valid Lemonade router policy JSON from a plain-English description of routing intent.
 * [local-ai-use](./local-ai-use.md): Teach your agent how to run image generation locally.

--- a/walkthroughs/hyperloom-workload-optimizer.md
+++ b/walkthroughs/hyperloom-workload-optimizer.md
@@ -1,4 +1,4 @@
-# AMD Skills Walkthroughs: `hyperloom-workload-optimizer`
+# hyperloom-workload-optimizer
 
 This skill teaches your AI agent to set up a Hyperloom workspace and autonomously
 optimize end-to-end LLM inference throughput on AMD Instinct GPUs (MI300X / MI325X / MI355X).

--- a/walkthroughs/hyperloom-workload-optimizer.md
+++ b/walkthroughs/hyperloom-workload-optimizer.md
@@ -1,4 +1,4 @@
-# hyperloom-workload-optimizer
+# AMD Skills Walkthroughs: `hyperloom-workload-optimizer`
 
 This skill teaches your AI agent to set up a Hyperloom workspace and autonomously
 optimize end-to-end LLM inference throughput on AMD Instinct GPUs (MI300X / MI325X / MI355X).

--- a/walkthroughs/lemonade-router-builder.md
+++ b/walkthroughs/lemonade-router-builder.md
@@ -1,4 +1,4 @@
-# AMD Skills Walkthroughs: `lemonade-router-builder`
+# lemonade-router-builder
 
 The goal of this skill is to teach your AI agent to turn a plain-English
 description of routing intent into a valid Lemonade `collection.router` policy
@@ -9,19 +9,20 @@ JSON, ready for you to register and use.
 
 - Claude Code installed and authenticated.
 
-## Step 1 - Install and start Lemonade Server
+## Step 1 — Install and start Lemonade Server
 
 Install the **latest** Lemonade Server (**v11.5.0 or later**) from
 <https://lemonade-server.ai/docs/guide/install/>, and download
 at least two chat-capable models:
 
+```bash
 lemonade status
 lemonade list
 ```
 
-Note the exact model names shown by `lemonade list` - you will use them in the prompts below. The examples use `<LARGE_MODEL>` , `<CLOUD_MODEL>`, and`<SMALL_MODEL` as placeholders; substitute the names of your two installed models (e.g. Gemma-4-31B-it-GGUF for large, Gemma-3-4b-it-GGUF for small, and kimi-k2p6 for cloud).
+Note the exact model names shown by `lemonade list` - you will use them in the prompts below. The examples use `<LARGE_MODEL>`, `<CLOUD_MODEL>`, and `<SMALL_MODEL>` as placeholders; substitute the names of your two installed models (for example, Gemma-4-31B-it-GGUF for large, Gemma-3-4b-it-GGUF for small, and kimi-k2p6 for cloud).
 
-## Step 2 - Confirm the skill is visible
+## Step 2 — Confirm the skill is visible
 
 ```bash
 claude "Which skills can you see?" --model sonnet
@@ -33,7 +34,7 @@ You should see `lemonade-router-builder` in the list. If not, install it from yo
 npx skills add amd/skills --skill lemonade-router-builder --agent claude-code
 ```
 
-## Step 3 - Generate a simple keyword router
+## Step 3 — Generate a keyword router
 
 Open Claude and run:
 
@@ -52,7 +53,7 @@ The agent should:
 4. Output the JSON in a fenced block, plus curl commands for you to register
    and test it.
 
-## Step 4 - Register and test the router yourself
+## Step 4 — Register and test the router yourself
 
 The agent will save the policy as `router.json`. Note the full path it reports,
 then run the curl commands **from the same directory** (or use the absolute path).
@@ -75,7 +76,7 @@ Check the `x-lemonade-route` response header - it should show the matched rule
 id. With `"route_trace": true` the body also contains `x_lemonade_route` with
 the full per-condition trace.
 
-## Step 5 - Try a PII privacy router
+## Step 5 — Try a PII privacy router
 
 On a new Claude session, run:
 
@@ -97,7 +98,7 @@ condition and test with the email address only instead:
 Any message containing an email address must stay on <SMALL_MODEL>. Everything else can go to <CLOUD_MODEL>.
 ```
 
-## Step 6 - Try an LLM-as-router (intent-only)
+## Step 6 — Try an LLM-as-router (intent-only)
 
 On a new Claude session, run:
 
@@ -112,7 +113,7 @@ because "sensitive" is a meaning judgment with no concrete signal. The
 generated prompt should describe routing intent only - no reply-format
 instructions.
 
-## Step 7 - (Optional) Try to get things done without the skill
+## Step 7 — (Optional) Try to get things done without the skill
 
 Remove the skill and ask the same routing questions. Without the skill, the
 agent is likely to produce JSON that fails the server-side parser on the first

--- a/walkthroughs/lemonade-router-builder.md
+++ b/walkthroughs/lemonade-router-builder.md
@@ -1,4 +1,4 @@
-# lemonade-router-builder
+# AMD Skills Walkthroughs: `lemonade-router-builder`
 
 The goal of this skill is to teach your AI agent to turn a plain-English
 description of routing intent into a valid Lemonade `collection.router` policy

--- a/walkthroughs/local-ai-app-integration.md
+++ b/walkthroughs/local-ai-app-integration.md
@@ -1,4 +1,4 @@
-# AMD Skills Walkthroughs: `local-ai-app-integration`
+# local-ai-app-integration
 
 The goal of this skill is to teach your AI agent to add a **local AI mode** to an
 existing app that today only talks to cloud AI APIs.
@@ -23,7 +23,7 @@ This sample app requires the Rust toolchain (install from https://rustup.rs/).
 | 2 | AMD iGPU / dGPU | GPU-accelerated transcription |
 | 3 (fallback) | Any other Windows x64 PC | CPU transcription |
 
-## Step 1 - Get the target app
+## Step 1 — Get the target app
 
 * Clone the cloud-only app you want to upgrade:
 
@@ -32,11 +32,11 @@ git clone https://github.com/danielholanda/dictate.git
 cd dictate
 ```
 
-## Step 2 - Understanding which skills are available
+## Step 2 — Understanding which skills are available
 
 * Run `claude "Which skills can you see?" --model opus`. You should see a list of skills that should *not* include anything related to local AI app integration.
 
-## Step 3 - Enabling claude to see `local-ai-app-integration`
+## Step 3 — Enabling Claude to see `local-ai-app-integration`
 
 * Install the skill with the [`skills` CLI](https://github.com/vercel-labs/skills). Run this in your terminal, not inside Claude:
 
@@ -46,7 +46,7 @@ npx skills add amd/skills --skill local-ai-app-integration --agent claude-code
 
 * Run `claude "Which skills can you see?" --model opus`. You should see a list of skills that includes `local-ai-app-integration`.
 
-## Step 4 - Running the skill
+## Step 4 — Running the skill
 
 Run `claude --model opus` inside the `dictate` repo with this prompt:
 
@@ -75,9 +75,9 @@ Claude should:
    weights are on disk before the first recording. Skipping this makes the very
    first transcription come back blank with no error.
 
-Please note this may take several minutes as this app has a fairly large codebase.
+This may take several minutes, as this app has a fairly large codebase.
 
-## Step 5 - Running the modified app
+## Step 5 — Running the modified app
 
 Dictate is a Tauri (Rust + Node) app. From the repo root:
 
@@ -115,13 +115,13 @@ cloud provider — the text appears where your cursor was last located.
 > now?\n"` on quiet audio are a known Whisper behavior on silence/low-energy
 > input, not an integration bug.
 
-## Step 6 - (Optional) Going beyond
+## Step 6 — (Optional) Going beyond
 
 `local-ai-app-integration` works for any modality, not just speech-to-text. The
 same pattern adds local chat, embeddings, image generation, or text-to-speech to
 any app that already calls into the cloud. You can try using this skill to turn other cloud apps into local apps.
 
-## Step 7 - (Optional) Try to get things done without AMD Skills
+## Step 7 — (Optional) Try to get things done without AMD Skills
 
 Remove the added skill from `.claude/skills/` and rerun the experiment above. This should lead to a high variance in execution length and token usage. Some common issues without the skill include:
 * Model produces a local implementation that does not use NPU acceleration as instructed.

--- a/walkthroughs/local-ai-app-integration.md
+++ b/walkthroughs/local-ai-app-integration.md
@@ -1,4 +1,4 @@
-# local-ai-app-integration
+# AMD Skills Walkthroughs: `local-ai-app-integration`
 
 The goal of this skill is to teach your AI agent to add a **local AI mode** to an
 existing app that today only talks to cloud AI APIs.

--- a/walkthroughs/local-ai-use.md
+++ b/walkthroughs/local-ai-use.md
@@ -1,4 +1,4 @@
-# local-ai-use
+# AMD Skills Walkthroughs: `local-ai-use`
 
 The goal of this skill is to teach your AI agent to use image generation, text generation, and text to speech locally.
 

--- a/walkthroughs/local-ai-use.md
+++ b/walkthroughs/local-ai-use.md
@@ -1,14 +1,14 @@
-# AMD Skills Walkthroughs: `local-ai-use`
+# local-ai-use
 
 The goal of this skill is to teach your AI agent to use image generation, text generation, and text to speech locally.
 
 
-## Step 1 - Understanding which skills are available
+## Step 1 — Understanding which skills are available
 
-* Run `claude "Which skills can you see?" --model sonnet`. You should see a list of skills that should not include anythink related to local LLM usage.
+* Run `claude "Which skills can you see?" --model sonnet`. You should see a list of skills that should not include anything related to local LLM usage.
 * Make sure there is no `AGENTS.md` file on your local folder.
 
-## Step 2 - Enabling claude to see `local-ai-use`
+## Step 2 — Enabling Claude to see `local-ai-use`
 
 * Install the skill with the [`skills` CLI](https://github.com/vercel-labs/skills). Run this in your terminal, not inside Claude:
 
@@ -18,7 +18,7 @@ npx skills add amd/skills --skill local-ai-use --agent claude-code
 
 * Run `claude "Which skills can you see?" --model sonnet`. You should see a list of skills that includes `local-ai-use`.
 
-## Step 3 - Running the skill
+## Step 3 — Running the skill
 
 Open Claude and run the prompt:
 ```
@@ -32,11 +32,11 @@ Generate the image of a cat
 
 Claude should install Lemonade locally on your device and allow you to generate images locally after the first setup run.
 
-## Step 4 - (Optional) Going beyond
+## Step 4 — (Optional) Going beyond
 
-The `local-ai-use` can also help you with text to speech and speech to text locally. Simply ask claude for help there.
+The `local-ai-use` can also help you with text to speech and speech to text locally. Ask Claude for help there.
 
-## Step 5 - (Optional) Try to get things done without AMD Skills
+## Step 5 — (Optional) Try to get things done without AMD Skills
 
 Remove the added skills from `.claude/skills/` and rerun the experiment above. This should lead to a high variance in execution length and token usage.
 * Model being successful after significant token usage.

--- a/walkthroughs/magpie-kernel-evaluator.md
+++ b/walkthroughs/magpie-kernel-evaluator.md
@@ -1,4 +1,4 @@
-# magpie-kernel-evaluator
+# AMD Skills Walkthroughs: `magpie-kernel-evaluator`
 
 Magpie connects model-serving benchmarks to GPU kernel optimization. This
 walkthrough follows the complete workflow:

--- a/walkthroughs/magpie-kernel-evaluator.md
+++ b/walkthroughs/magpie-kernel-evaluator.md
@@ -404,4 +404,4 @@ a config shape, compare performance before correctness, or omit the structured
 reports needed for review.
 
 For the complete command and configuration reference, read the
-[`magpie-kernel-evaluator` skill](../skills/magpie-kernel-evaluator/SKILL.md).
+[`magpie-kernel-evaluator` skill](https://github.com/amd/skills/blob/main/skills/magpie-kernel-evaluator/SKILL.md).

--- a/walkthroughs/magpie-kernel-evaluator.md
+++ b/walkthroughs/magpie-kernel-evaluator.md
@@ -1,4 +1,4 @@
-# AMD Skills Walkthroughs: `magpie-kernel-evaluator`
+# magpie-kernel-evaluator
 
 Magpie connects model-serving benchmarks to GPU kernel optimization. This
 walkthrough follows the complete workflow:
@@ -116,7 +116,7 @@ magpie benchmark \
 Review request/token throughput, completed requests, TTFT, TPOT, ITL, and
 end-to-end latency. Record the Magpie commit, model revision, image/framework
 version, GPU model and count, tensor parallelism, precision, concurrency,
-input/output lengths, warmup, and profiler state.
+input and output lengths, warmup, and profiler state.
 
 ### Review TraceLens post-processing
 

--- a/walkthroughs/serving-llms-on-epyc.md
+++ b/walkthroughs/serving-llms-on-epyc.md
@@ -1,4 +1,4 @@
-# AMD Skills Walkthroughs: `serving-llms-on-epyc`
+# serving-llms-on-epyc
 
 The goal of this skill is to teach your AI agent to bring up a vLLM OpenAI-compatible
 endpoint on an **AMD EPYC™ CPU** host using the zentorch backend: detecting the CPU,
@@ -6,24 +6,24 @@ validating the environment, checking the model fits, sizing the runtime to the
 hardware, launching, and verifying the endpoint responds.
 
 **What you'll end up with:** a running `vllm serve` endpoint on your EPYC box (in a
-Docker/Podman container, or a conda env), sized to a single socket and ready to answer
-OpenAI requests via `/v1/chat/completions` for instruct/chat models (those that ship a
+Docker or Podman container, or a conda env), sized to a single socket and ready to answer
+OpenAI requests through `/v1/chat/completions` for instruct/chat models (those that ship a
 chat template) or `/v1/completions` for base models.
 
 ## Prerequisites
 
-- A supported **AMD EPYC™ 9000-series server CPU with AVX-512**: **Genoa** (9004), **Turin** (9005), or **6th Gen Venice** (9006). `detect.py` reports both `is_supported_epyc` and `avx512`; both must be true. Other EPYC parts (Bergamo, Siena, the AM5 EPYC 4004/4005) may expose AVX-512 but are outside this skill's current 9000-series scope and are treated as unsupported. This is CPU serving; a GPU is not required, but a host may also contain AMD Instinct GPUs.
+- A supported **AMD EPYC™ 9000-series server CPU with AVX-512**: **Genoa** (9004), **Turin** (9005), or **6th Gen Venice** (9006). `detect.py` reports both `is_supported_epyc` and `avx512`; both must be true. Other EPYC parts (Bergamo, Siena, the AM5 EPYC 4004/4005) might expose AVX-512 but are outside this skill's current 9000-series scope and are treated as unsupported. This is CPU serving; a GPU is not required, but a host may also contain AMD Instinct GPUs.
 - A container runtime (**Docker** or **Podman**), or a conda env with `vllm` + `zentorch` installed.
 - Enough host RAM for the model (weights + KV cache both live in RAM on CPU).
 - A HuggingFace token in `HF_TOKEN` **only** for gated models (Llama, Gemma). The default model (Qwen3) needs none.
-- **Node.js ≥ 18**, required by the `skills` CLI used in Step 2 (`npx skills ...`). Check with `node -v`; on older hosts install a newer Node (e.g. `conda create -n node20 -c conda-forge 'nodejs>=20'`).
+- **Node.js ≥ 18**, required by the `skills` CLI used in Step 2 (`npx skills ...`). Check with `node -v`; on older hosts install a newer Node (for example, `conda create -n node20 -c conda-forge 'nodejs>=20'`).
 
-## Step 1 - Understanding which skills are available
+## Step 1 — Understanding which skills are available
 
 * Start in a clean scratch directory, then run `claude "Which skills can you see?" --model sonnet`. You should see a list of skills that does **not** include anything about serving LLMs on EPYC / CPU.
 * Confirm the scratch directory has no `AGENTS.md`, `CLAUDE.md`, `.claude/skills`, or `.agents/skills`. Existing agent instructions or installed skill copies can change discovery and invalidate the before/after comparison. Do not delete instructions from a real project; use a clean scratch directory instead.
 
-## Step 2 - Enabling claude to see `serving-llms-on-epyc`
+## Step 2 — Enabling Claude to see `serving-llms-on-epyc`
 
 * Install the skill with the [`skills` CLI](https://github.com/vercel-labs/skills). Run this in your terminal, not inside Claude:
 
@@ -33,7 +33,7 @@ npx skills add amd/skills --skill serving-llms-on-epyc --agent claude-code
 
 * Run `claude "Which skills can you see?" --model sonnet`. You should see a list of skills that now includes `serving-llms-on-epyc`.
 
-## Step 3 - Running the skill
+## Step 3 — Running the skill
 
 Run `claude --model sonnet` on your EPYC host with this prompt:
 
@@ -53,7 +53,7 @@ Claude should:
 
 On any failure it reports the cause + logs and **stops**; it does not retry or start a debugging loop.
 
-## Step 4 - Talk to the endpoint
+## Step 4 — Talk to the endpoint
 
 Once Claude reports the endpoint is healthy, use the **base URL, served-model name,
 and endpoint from Claude's connection table** (it uses port `8000` by default). Qwen3
@@ -94,13 +94,13 @@ print(r.choices[0].message.content)
 served `--max-model-len`. Set `temperature` (0 for deterministic) and `stream=True`
 to stream tokens.
 
-## Step 5 - (Optional) Going beyond
+## Step 5 — (Optional) Going beyond
 
-* **A real workload:** ask for a larger model once the flow is proven, e.g. *"Serve Qwen/Qwen3-8B ..."*. Claude re-checks the RAM fit and re-sizes.
+* **A real workload:** ask for a larger model once the flow is proven, for example *"Serve Qwen/Qwen3-8B ..."*. Claude re-checks the RAM fit and re-sizes.
 * **Gated models:** `export HF_TOKEN=...` (and accept the model license on HuggingFace), then ask for `meta-llama/Llama-3.1-8B-Instruct`.
 * **Pick a socket:** on a dual-socket box Claude picks a free socket by load; you can steer it (*"serve it on socket 1"*).
 
-## Step 6 - (Optional) Try to get things done without AMD Skills
+## Step 6 — (Optional) Try to get things done without AMD Skills
 
 Remove the added skill and rerun the experiment above. The `skills` CLI installs a
 copy under **both** `.claude/skills/serving-llms-on-epyc` **and**

--- a/walkthroughs/serving-llms-on-epyc.md
+++ b/walkthroughs/serving-llms-on-epyc.md
@@ -1,4 +1,4 @@
-# serving-llms-on-epyc
+# AMD Skills Walkthroughs: `serving-llms-on-epyc`
 
 The goal of this skill is to teach your AI agent to bring up a vLLM OpenAI-compatible
 endpoint on an **AMD EPYC™ CPU** host using the zentorch backend: detecting the CPU,

--- a/walkthroughs/tracelens-analysis-orchestrator.md
+++ b/walkthroughs/tracelens-analysis-orchestrator.md
@@ -1,4 +1,4 @@
-# AMD Skills Walkthroughs: `tracelens-analysis-orchestrator`
+# tracelens-analysis-orchestrator
 
 The goal of this skill is to teach your AI agent to run the TraceLens agentic
 analysis workflow on a PyTorch trace and produce a prioritized stakeholder
@@ -26,7 +26,7 @@ Expect this process to take 5–30 minutes depending on trace size.
 For vLLM / SGLang inference traces, the canonical collection guide in
 [TraceLens Inference Analysis](https://github.com/AMD-AGI/TraceLens/blob/main/docs/conceptual/inference-analysis.md)
 provides detailed instructions about collecting traces.
-Including capture mode graphs will produce better results but may require patching vLLM or SGLang.
+Including capture mode graphs will produce better results but might require patching vLLM or SGLang.
 
 ## Prerequisites
 
@@ -42,12 +42,12 @@ Including capture mode graphs will produce better results but may require patchi
 - A PyTorch profiler trace (`.json` or `.json.gz`) from a representative
   steady-state window (post-warmup). A single rank's trace is sufficient for
   per-rank analysis.
-- The **platform** of the first trace (e.g. `MI300X`, `MI325X`) — used for
+- The **platform** of the first trace (for example, `MI300X`, `MI325X`) — used for
   roofline limits and hardware reference in the report
 
-## Step 1 - Understanding which skills are available
+## Step 1 — Understanding which skills are available
 
-* Run `claude "which skills do you see?"`. You should see a list of skills that should not include anythink related to TraceLens.
+* Run `claude "which skills do you see?"`. You should see a list of skills that should not include anything related to TraceLens.
 * Make sure there is no `AGENTS.md` file on your local folder.
 
 ## Step 2 — Enabling your agent to see `tracelens-analysis-orchestrator`
@@ -180,7 +180,7 @@ analysis mode default, output to ./analysis_output_comparative
 Comparative output adds per-trace perf reports (`perf_report_trace1.xlsx`,
 `perf_report_trace2.xlsx`) and gap-based impact estimates in `category_data/`.
 
-> Cross-framework comparisons (e.g. vLLM vs. SGLang) may produce misleading gap
+> Cross-framework comparisons (for example, vLLM vs. SGLang) might produce misleading gap
 > estimates due to structural differences in operation call stacks.
 
 ## Step 8 — (Optional) Headless runs with the Cursor `agent` CLI

--- a/walkthroughs/tracelens-analysis-orchestrator.md
+++ b/walkthroughs/tracelens-analysis-orchestrator.md
@@ -1,4 +1,4 @@
-# tracelens-analysis-orchestrator
+# AMD Skills Walkthroughs: `tracelens-analysis-orchestrator`
 
 The goal of this skill is to teach your AI agent to run the TraceLens agentic
 analysis workflow on a PyTorch trace and produce a prioritized stakeholder

--- a/walkthroughs/tracelens-analysis-orchestrator.md
+++ b/walkthroughs/tracelens-analysis-orchestrator.md
@@ -228,8 +228,8 @@ length, token usage, and report quality. Common issues without the skill include
 
 - **Inference profiling:** Use the TraceLens profiling skill
   ([`magpie-benchmark-profiling`](https://github.com/AMD-AGI/TraceLens/blob/main/TraceLens/Agent/Profiling/README.md))
-  or the [`magpie-kernel-evaluator`](../skills/magpie-kernel-evaluator/SKILL.md)
-  skill to collect vLLM/SGLang traces before analysis.
+  or try the [`magpie-kernel-evaluator`](https://github.com/amd/skills/blob/main/walkthroughs/magpie-kernel-evaluator.md)
+  walkthrough to collect vLLM/SGLang traces before analysis.
 - **Optimization loop:** Parse `analysis.md` P-items and impact markers to drive
   kernel tuning, fusion, batching, or precision narrowing, then re-profile and
   re-run analysis to measure improvement.


### PR DESCRIPTION
Adds a Sphinx documentation site under `docs/rocm-docs/`, single-sourced from `README.md` and `walkthroughs/` via MyST `{include}` directives so the docs and repo content stay in sync automatically.

Covers installation, core concepts, the skill catalog, licensing, and all 7 walkthroughs, and is set up to publish on Read the Docs.

Also includes editorial pass of existing README content.

Updated some links to be absolute so they work in a RTD doc.