### PR TITLE
Enable external repos to run extended tests beyond `evals.json`

### DIFF
--- a/.github/scripts/select_evals.py
+++ b/.github/scripts/select_evals.py
@@ -9,6 +9,7 @@ Emits one JSON object on stdout::
 
     {
       "routing": true,
+      "extended": false,
       "default": [
         {"skill": "local-ai-use", "os": "Linux",
          "runner": "[\\"self-hosted\\",\\"strix_halo\\",\\"Linux\\"]", "gate": ""}
@@ -34,6 +35,12 @@ The split is by credentials, not by hardware: a runner class with its own
 ``environment`` reads that environment's scoped secrets, and one without uses
 the repo-wide key for AMD's internal gateway. They are separate jobs because a
 job's credentials have to be fixed before its matrix expands.
+
+``extended`` echoes back whether the optional ``evals/extended_evals.json``
+datasets are in play, so the workflow decides that once and every job reads the
+same answer. It has to match what the runner is passed: selecting a skill whose
+only graded prompts live in a dataset the run then ignores schedules a job with
+nothing to do.
 
 ``skipped`` holds legs whose gate label is missing from the pull request. A
 gate comes with the runner class -- the Instinct pool always requires
@@ -62,6 +69,12 @@ sys.path.insert(0, str(REPO_ROOT / "eval"))
 
 import datasets  # noqa: E402
 
+# The two dataset files a change can touch, as `git diff --name-only` spells
+# them. Derived rather than written out, so renaming one here is not a silent
+# way to stop selecting runs for it.
+DATASET_SUFFIX = "/" + datasets.DATASET_RELPATH.as_posix()
+EXTENDED_SUFFIX = "/" + datasets.EXTENDED_DATASET_RELPATH.as_posix()
+
 # Touching any of these changes the shared engine rather than one skill, so
 # every skill is re-run rather than guessing at the blast radius. Repo-root
 # relative with forward slashes, to match `git diff --name-only`.
@@ -79,20 +92,25 @@ INFRA_FILES = {
 }
 
 
-def has_behavior_cases(skill: str) -> bool:
+def has_behavior_cases(skill: str, extended: bool = True) -> bool:
     """Whether this skill asserts anything a behavior run could grade."""
-    return any(case.has_behavior for case in datasets.load_dataset(skill))
+    return any(
+        case.has_behavior for case in datasets.load_dataset(skill, extended=extended)
+    )
 
 
 def matrix_entries(
-    skills: list[str], labels: set[str], ignore_gates: bool = False
+    skills: list[str],
+    labels: set[str],
+    ignore_gates: bool = False,
+    extended: bool = True,
 ) -> tuple[list[dict], list[dict]]:
     """Split `skills` into matrix legs to run and legs held back by a gate."""
     include: list[dict] = []
     skipped: list[dict] = []
 
     for skill in skills:
-        if not has_behavior_cases(skill):
+        if not has_behavior_cases(skill, extended):
             continue
         plan = datasets.machine_plan(skill)
         gate = plan["gate"]
@@ -113,7 +131,7 @@ def matrix_entries(
     return include, skipped
 
 
-def routing_needed(changed: set[str]) -> bool:
+def routing_needed(changed: set[str], extended: bool = True) -> bool:
     """Whether the change can move a routing decision.
 
     A skill's description and its prompts are the only inputs to routing, so a
@@ -123,13 +141,16 @@ def routing_needed(changed: set[str]) -> bool:
     An unpublished skill's description is not an input either: routing installs
     the published bundle, so that skill is not in the room to win or lose a
     prompt. Its dataset still counts, because its near-miss prompts are graded
-    against the skills that are.
+    against the skills that are. An extended dataset counts only where it runs:
+    editing prompts this repo never grades should not buy a catalog-wide run.
     """
     if changed & INFRA_FILES:
         return True
     published = set(datasets.routing_catalog())
     for path in changed:
-        if path.endswith("/evals/evals.json"):
+        if path.endswith(DATASET_SUFFIX):
+            return True
+        if extended and path.endswith(EXTENDED_SUFFIX):
             return True
         if path.endswith("/SKILL.md"):
             parts = path.split("/")
@@ -164,6 +185,13 @@ def main(argv: list[str] | None = None) -> int:
         "--ignore-gates", action="store_true",
         help="Run gated skills without their label. For workflow_dispatch, which is already explicit human intent.",
     )
+    parser.add_argument(
+        "--extended", action=argparse.BooleanOptionalAction, default=True,
+        help=(
+            "Count each skill's optional evals/extended_evals.json as a run "
+            "input. On by default; must match the flag the runner is given."
+        ),
+    )
     args = parser.parse_args(argv)
 
     available = datasets.skills_with_datasets()
@@ -186,15 +214,18 @@ def main(argv: list[str] | None = None) -> int:
             if line.strip()
         }
         skills = select_from_changes(changed)
-        routing = routing_needed(changed)
+        routing = routing_needed(changed, args.extended)
 
     labels = {token.strip() for token in args.labels.split(",") if token.strip()}
-    include, skipped = matrix_entries(skills, labels, ignore_gates=args.ignore_gates)
+    include, skipped = matrix_entries(
+        skills, labels, ignore_gates=args.ignore_gates, extended=args.extended
+    )
 
     print(
         json.dumps(
             {
                 "routing": routing,
+                "extended": args.extended,
                 "default": [leg for leg in include if "environment" not in leg],
                 "scoped": [leg for leg in include if "environment" in leg],
                 "skipped": skipped,

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -15,6 +15,10 @@ name: evals
 # SKILL.md description or a dataset), and behavior runs only for the skills a
 # change touches. The whole suite runs when the shared engine changes.
 #
+# A skill may also ship evals/extended_evals.json, in the same format and with
+# no coverage requirement of its own. Whether those prompts run is the
+# RUN_EXTENDED_EVALS knob below; the required evals.json always runs.
+#
 # Which class of machine a skill's behavior job needs is declared by the skill,
 # in skills/<name>/evals/machine.yml, and resolved to labels, gates, and
 # credentials by eval/datasets.py. Nothing here names a skill: a hardcoded list
@@ -65,6 +69,15 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  # Whether a skill's optional skills/<name>/evals/extended_evals.json is run
+  # alongside the required evals.json. Off here: this catalog grades the
+  # required dataset only, and a product repo's extra prompts are that repo's
+  # bill to pay. A repo vendoring this harness sets this to "true" -- which is
+  # also what eval/run_evals.py does when nobody passes the flag. Either way
+  # extended datasets are still structurally validated.
+  RUN_EXTENDED_EVALS: "false"
+
 jobs:
   # Secret-free: structural validation, the engine's own unit tests, and a git
   # diff. All three are free and fast, so a malformed dataset or a broken
@@ -74,6 +87,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       routing: ${{ steps.select.outputs.routing }}
+      # The runner flag, resolved once here so selection and every run job
+      # agree on whether extended datasets are in play.
+      extended: ${{ steps.select.outputs.extended }}
       default: ${{ steps.select.outputs.default }}
       default_any: ${{ steps.select.outputs.default_any }}
       scoped: ${{ steps.select.outputs.scoped }}
@@ -110,13 +126,19 @@ jobs:
           LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
         run: |
           set -euo pipefail
+          # The harness default is on, so only an explicit "false" turns it off.
+          if [ "${RUN_EXTENDED_EVALS:-true}" = "false" ]; then
+            extended=--no-extended
+          else
+            extended=--extended
+          fi
           if [ "$EVENT" = "workflow_dispatch" ]; then
             # A dispatch is already explicit human intent, so gate labels are
             # not required on top of it.
             if [ -n "$SKILLS" ]; then
-              plan=$(uv run .github/scripts/select_evals.py --names "$SKILLS" --ignore-gates)
+              plan=$(uv run .github/scripts/select_evals.py --names "$SKILLS" --ignore-gates "$extended")
             else
-              plan=$(uv run .github/scripts/select_evals.py --all --ignore-gates)
+              plan=$(uv run .github/scripts/select_evals.py --all --ignore-gates "$extended")
             fi
             if [ "$MODE" = "behavior" ]; then
               plan=$(printf '%s' "$plan" | python3 -c \
@@ -129,14 +151,19 @@ jobs:
             plan=$(git diff --name-only \
               "${{ github.event.pull_request.base.sha }}" \
               "${{ github.event.pull_request.head.sha }}" \
-              | uv run .github/scripts/select_evals.py --changed --labels "$LABELS")
+              | uv run .github/scripts/select_evals.py --changed --labels "$LABELS" "$extended")
           fi
 
           echo "Plan: $plan"
           printf '%s' "$plan" | python3 -c '
           import json, os, sys
           plan = json.load(sys.stdin)
-          lines = ["routing=" + str(plan["routing"]).lower()]
+          lines = [
+              "routing=" + str(plan["routing"]).lower(),
+              # Emitted as the flag itself: every run job passes it through
+              # verbatim rather than re-deriving the same boolean.
+              "extended=" + ("--extended" if plan["extended"] else "--no-extended"),
+          ]
           for key in ("default", "scoped", "skipped"):
               lines.append(key + "=" + json.dumps(plan[key]))
           for key in ("default", "scoped"):
@@ -190,12 +217,14 @@ jobs:
         env:
           ONLY: ${{ github.event.inputs.only }}
           MIN_ACCURACY: ${{ github.event.inputs.min_accuracy || '0' }}
+          EXTENDED: ${{ needs.discover.outputs.extended }}
         run: |
           set -euo pipefail
           python eval/run_evals.py \
             --mode routing \
             --only "$ONLY" \
             --min-accuracy "$MIN_ACCURACY" \
+            "$EXTENDED" \
             --output routing-report.json \
             --keep-logs routing-logs
 
@@ -247,7 +276,9 @@ jobs:
         run: npm install -g @anthropic-ai/claude-code
 
       - name: Run behavior cases for ${{ matrix.skill }}
-        run: python eval/run_evals.py --mode behavior --skill ${{ matrix.skill }}
+        env:
+          EXTENDED: ${{ needs.discover.outputs.extended }}
+        run: python eval/run_evals.py --mode behavior --skill ${{ matrix.skill }} "$EXTENDED"
 
   # Skills on a runner class that carries its own environment. Those bring
   # scoped secrets, which is why they cannot share the job above: a job's
@@ -296,7 +327,9 @@ jobs:
         run: npm install -g @anthropic-ai/claude-code
 
       - name: Run behavior cases for ${{ matrix.skill }}
-        run: python eval/run_evals.py --mode behavior --skill ${{ matrix.skill }}
+        env:
+          EXTENDED: ${{ needs.discover.outputs.extended }}
+        run: python eval/run_evals.py --mode behavior --skill ${{ matrix.skill }} "$EXTENDED"
 
   # Single aggregate gate. Mark THIS check required in branch protection.
   #

--- a/docs/evals.md
+++ b/docs/evals.md
@@ -57,6 +57,10 @@ Every evaluation is a prompt plus `skill_should_trigger`: `true` if your skill s
 - At least **1** of the `true` evaluations carries `expected_behavior` or
   `unexpected_behavior`, so something beyond triggering is graded
 
+### Extended validation
+
+`evals/evals.json` is the only dataset we require, and the only one this repo runs. A skill may ship a second file beside it, `evals/extended_evals.json`, which runs as part of the product repo for extended validation.
+
 ### Evaluation criteria and optional fields
 
 Four optional fields, all arrays, all valid only on a `true` evaluation:

--- a/eval/datasets.py
+++ b/eval/datasets.py
@@ -15,6 +15,14 @@ true once it has::
       "prompt": "Serve Llama 3.1 8B with zentorch."
     }
 
+A skill may ship a second dataset in the same format at
+``skills/<name>/evals/extended_evals.json``. It is optional, it carries no
+coverage requirement of its own -- the tier-0 bar below is counted over
+``evals.json`` alone -- and whether it runs at all is the caller's decision
+(``extended=True`` here, ``--extended`` on the runner). It is where a product
+repo keeps the prompts it wants graded in its own CI without every consumer of
+the catalog paying for them.
+
 There are two run modes to satisfy:
 
   * **routing** -- the published bundle is installed side by side and only the
@@ -72,6 +80,9 @@ CLAUDE_MARKETPLACE = REPO_ROOT / ".claude-plugin" / "marketplace.json"
 
 # One dataset per skill, beside the skill it describes.
 DATASET_RELPATH = Path("evals") / "evals.json"
+# The optional second dataset: same format, no coverage bar, only run when the
+# caller asks for it.
+EXTENDED_DATASET_RELPATH = Path("evals") / "extended_evals.json"
 HOOKS_RELPATH = Path("evals") / "hooks.py"
 MACHINE_RELPATH = Path("evals") / "machine.yml"
 
@@ -166,6 +177,9 @@ class Case:
     # Directory (relative to the skill root) whose contents seed the workspace.
     workspace: str | None = None
     note: str = ""
+    # Came from `evals/extended_evals.json` rather than the required dataset,
+    # so it does not count towards our requirements bar and only runs when asked for.
+    extended: bool = False
 
     @property
     def expect_skill(self) -> str | None:
@@ -201,6 +215,10 @@ class Case:
 
 def dataset_path(skill: str) -> Path:
     return SKILLS_DIR / skill / DATASET_RELPATH
+
+
+def extended_dataset_path(skill: str) -> Path:
+    return SKILLS_DIR / skill / EXTENDED_DATASET_RELPATH
 
 
 def hooks_path(skill: str) -> Path:
@@ -281,7 +299,13 @@ def routing_cases(cases: list[Case], catalog: list[str]) -> list[Case]:
     return [case for case in cases if case.expect_skill is None or case.expect_skill in installed]
 
 
-def _parse_case(entry: object, skill: str | None, label: str, errors: list[str]) -> Case | None:
+def _parse_case(
+    entry: object,
+    skill: str | None,
+    label: str,
+    errors: list[str],
+    extended: bool = False,
+) -> Case | None:
     """Turn one array element into a Case, appending any problems found."""
     if not isinstance(entry, dict):
         errors.append(f"{label} must be an object.")
@@ -366,10 +390,17 @@ def _parse_case(entry: object, skill: str | None, label: str, errors: list[str])
         files_exist=lists["files_exist"],
         workspace=workspace.strip() if isinstance(workspace, str) else None,
         note=note,
+        extended=extended,
     )
 
 
-def _parse_cases(payload: object, skill: str | None, source: Path, errors: list[str]) -> list[Case]:
+def _parse_cases(
+    payload: object,
+    skill: str | None,
+    source: Path,
+    errors: list[str],
+    extended: bool = False,
+) -> list[Case]:
     """Turn one parsed dataset file into cases, appending any problems found."""
     where = source.name
 
@@ -388,26 +419,47 @@ def _parse_cases(payload: object, skill: str | None, source: Path, errors: list[
 
     cases: list[Case] = []
     for index, entry in enumerate(raw):
-        case = _parse_case(entry, skill, f"{where}: {EVALUATIONS_KEY}[{index}]", errors)
+        case = _parse_case(
+            entry, skill, f"{where}: {EVALUATIONS_KEY}[{index}]", errors, extended
+        )
         if case is not None:
             cases.append(case)
     return cases
 
 
-def load_dataset(skill: str, errors: list[str] | None = None) -> list[Case]:
-    """Cases from one skill's dataset. Raises SystemExit on error unless collecting."""
+def _read_dataset(
+    skill: str, path: Path, collected: list[str], extended: bool
+) -> list[Case]:
+    """Parse one dataset file, reporting a read or JSON problem as an error."""
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        collected.append(f"{skill}/{path.name}: invalid JSON: {exc}")
+        return []
+    return _parse_cases(payload, skill, path, collected, extended)
+
+
+def load_dataset(
+    skill: str, errors: list[str] | None = None, *, extended: bool = False
+) -> list[Case]:
+    """Cases for one skill. Raises SystemExit on error unless collecting.
+
+    The required dataset always, plus ``evals/extended_evals.json`` when
+    `extended` and the skill ships one. An absent extended dataset is the
+    common case and not a problem: the file is optional by design.
+    """
     collected: list[str] = [] if errors is None else errors
     path = dataset_path(skill)
     if not path.is_file():
         collected.append(f"{skill}: missing {DATASET_RELPATH.as_posix()}.")
         cases: list[Case] = []
     else:
-        try:
-            payload = json.loads(path.read_text(encoding="utf-8"))
-        except json.JSONDecodeError as exc:
-            collected.append(f"{skill}/{path.name}: invalid JSON: {exc}")
-            payload = None
-        cases = _parse_cases(payload, skill, path, collected) if payload is not None else []
+        cases = _read_dataset(skill, path, collected, False)
+
+    if extended:
+        extra = extended_dataset_path(skill)
+        if extra.is_file():
+            cases.extend(_read_dataset(skill, extra, collected, True))
 
     if errors is None and collected:
         raise SystemExit("error: " + "\n       ".join(collected))
@@ -431,7 +483,7 @@ def load_shared_negatives(errors: list[str] | None = None) -> list[Case]:
     return cases
 
 
-def load_all_cases(errors: list[str] | None = None) -> list[Case]:
+def load_all_cases(errors: list[str] | None = None, *, extended: bool = False) -> list[Case]:
     """Every case in the repo: each skill's dataset plus the shared pool.
 
     Routing grades against this whole set at once, which is where the coverage
@@ -441,7 +493,7 @@ def load_all_cases(errors: list[str] | None = None) -> list[Case]:
     """
     cases: list[Case] = []
     for skill in skills_with_datasets():
-        cases.extend(load_dataset(skill, errors))
+        cases.extend(load_dataset(skill, errors, extended=extended))
     cases.extend(load_shared_negatives(errors))
     return cases
 
@@ -469,7 +521,7 @@ def validate_all() -> list[str]:
     seconds rather than halfway through a paid run.
     """
     errors: list[str] = []
-    cases = load_all_cases(errors)
+    cases = load_all_cases(errors, extended=True)
     catalog = set(catalog_skills())
 
     for case_id in duplicate_ids(cases):
@@ -489,12 +541,17 @@ def validate_all() -> list[str]:
                 )
 
     for skill in catalog:
-        errors.extend(tier0_errors(skill, [c for c in cases if c.skill == skill]))
+        errors.extend(
+            tier0_errors(skill, [c for c in cases if c.skill == skill and not c.extended])
+        )
     return errors
 
 
 def tier0_errors(skill: str, cases: list[Case]) -> list[str]:
-    """Whether `skill` meets the mandatory coverage bar."""
+    """Whether `skill` meets the mandatory coverage bar.
+
+    Counted over the required dataset alone (evals.json).
+    """
     if not dataset_path(skill).is_file():
         return [
             f"{skill}: no eval dataset. Every skill needs "

--- a/eval/run_evals.py
+++ b/eval/run_evals.py
@@ -15,6 +15,11 @@ runner reads those datasets and grades them in two modes:
     / ``files_exist``. Only runs evaluations that assert something beyond the
     routing decision.
 
+A skill may also ship ``skills/<name>/evals/extended_evals.json``, in the same
+format and under no coverage requirement of its own. Both modes include it by
+default; ``--no-extended`` grades the required dataset alone, which is what a
+repo that only owes the required tier passes.
+
 The prompt is written once and both modes read it, which is the whole point:
 the old split had a central routing prompt set and a separate per-skill pytest
 file that re-asserted routing with a substring match on the transcript.
@@ -27,9 +32,9 @@ Usage::
     # structural checks only: no agent, no tokens, instant
     python eval/run_evals.py --validate
 
-    # what CI runs
-    python eval/run_evals.py --mode routing --min-accuracy 0.9
-    python eval/run_evals.py --mode behavior --skill local-ai-use
+    # what CI runs (this repo grades the required datasets only)
+    python eval/run_evals.py --mode routing --min-accuracy 0.9 --no-extended
+    python eval/run_evals.py --mode behavior --skill local-ai-use --no-extended
 
     # one case, keeping the raw transcript
     python eval/run_evals.py --only qwen-on-mi300x --keep-logs eval-logs
@@ -338,6 +343,16 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--only", default="", help="Comma-separated case ids to run.")
     parser.add_argument(
+        "--extended",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Also run each skill's optional evals/extended_evals.json, when it "
+            "has one. On by default; `--no-extended` grades the required "
+            "evals.json alone."
+        ),
+    )
+    parser.add_argument(
         "--validate",
         action="store_true",
         help="Check every dataset structurally and exit. No agent, no tokens.",
@@ -410,7 +425,9 @@ def main(argv: list[str] | None = None) -> int:
         return 1
     if args.validate:
         skills = datasets.skills_with_datasets()
-        cases = datasets.load_all_cases()
+        # Extended datasets are validated regardless of --extended, so count
+        # them here too rather than reporting fewer cases than were checked.
+        cases = datasets.load_all_cases(extended=True)
         print(
             f"[evals] OK: {len(cases)} case(s) across {len(skills)} skill(s) "
             f"plus {len(datasets.load_shared_negatives())} shared negative(s)."
@@ -440,7 +457,7 @@ def main(argv: list[str] | None = None) -> int:
         # Pool every published skill's cases: skill Y's positives are skill X's
         # negatives, which is where most of the false-trigger coverage comes
         # from. --skill narrows what is *reported on*, not what is installed.
-        cases = datasets.load_all_cases()
+        cases = datasets.load_all_cases(extended=args.extended)
         held_out = sorted(
             {c.skill for c in cases if c.skill and c.skill not in set(catalog)}
         )
@@ -497,6 +514,7 @@ def main(argv: list[str] | None = None) -> int:
                 "effort": args.effort,
                 "skills": catalog,
                 "held_out_skills": held_out,
+                "extended": args.extended,
                 "wall_time_s": round(time.time() - started, 1),
                 "max_tool_calls": args.max_tool_calls,
                 "max_inspection_calls": args.max_inspection_calls,
@@ -531,7 +549,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.mode in ("behavior", "both"):
         cases = []
         for skill in skills:
-            cases.extend(datasets.load_dataset(skill))
+            cases.extend(datasets.load_dataset(skill, extended=args.extended))
         if args.only:
             cases = datasets.filter_cases(cases, args.only)
         gradable = [c for c in cases if c.has_behavior]
@@ -551,6 +569,7 @@ def main(argv: list[str] | None = None) -> int:
                     "model": args.model,
                     "effort": args.effort,
                     "skills": skills,
+                    "extended": args.extended,
                     "wall_time_s": round(time.time() - started, 1),
                     "github_run_id": os.environ.get("GITHUB_RUN_ID"),
                 },

--- a/eval/schema/evals.schema.json
+++ b/eval/schema/evals.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/amd/skills/eval/schema/evals.schema.json",
   "title": "AMD skill eval dataset",
-  "description": "One dataset per skill at skills/<name>/evals/evals.json, holding an `evaluations` array. Each evaluation is a prompt plus `skill_should_trigger`, a yes/no answer to whether the skill that owns this file should fire for it. No evaluation names a skill; the folder does that. Routing mode installs the whole catalog and grades the trigger decision for every evaluation. Behavior mode installs only this skill and grades expected_behavior / unexpected_behavior / logs_contain / files_exist, which is why those fields exist only when skill_should_trigger is true. eval/datasets.py is the enforcing implementation and `python eval/run_evals.py --validate` is how you run it; this file is the field reference, and datasets do not link to it.",
+  "description": "One dataset per skill at skills/<name>/evals/evals.json, holding an `evaluations` array. The same shape describes the optional skills/<name>/evals/extended_evals.json, which carries no coverage requirement and only runs when the runner is asked for it. Each evaluation is a prompt plus `skill_should_trigger`, a yes/no answer to whether the skill that owns this file should fire for it. No evaluation names a skill; the folder does that. Routing mode installs the whole catalog and grades the trigger decision for every evaluation. Behavior mode installs only this skill and grades expected_behavior / unexpected_behavior / logs_contain / files_exist, which is why those fields exist only when skill_should_trigger is true. eval/datasets.py is the enforcing implementation and `python eval/run_evals.py --validate` is how you run it; this file is the field reference, and datasets do not link to it.",
   "type": "object",
   "additionalProperties": false,
   "required": ["evaluations"],
@@ -17,7 +17,7 @@
     "evaluations": {
       "type": "array",
       "minItems": 1,
-      "description": "Every prompt this skill is graded on, triggering and non-triggering alike. Tier 0 requires at least 3 with skill_should_trigger true and 2 with it false.",
+      "description": "Every prompt this skill is graded on, triggering and non-triggering alike. Tier 0 requires at least 3 with skill_should_trigger true and 2 with it false, counted over evals.json alone.",
       "items": {
         "oneOf": [
           { "$ref": "#/$defs/triggeringEvaluation" },

--- a/eval/test_evals.py
+++ b/eval/test_evals.py
@@ -34,13 +34,16 @@ TRIGGERING = "triggeringEvaluation"
 NON_TRIGGERING = "nonTriggeringEvaluation"
 
 
-def parse(payload: dict, skill: str | None = "demo-skill") -> tuple[list, list[str]]:
+def parse(
+    payload: dict, skill: str | None = "demo-skill", extended: bool = False
+) -> tuple[list, list[str]]:
     """Run the dataset parser over an in-memory payload."""
     errors: list[str] = []
     with tempfile.TemporaryDirectory() as tmp:
-        source = Path(tmp) / "evals.json"
+        name = "extended_evals.json" if extended else "evals.json"
+        source = Path(tmp) / name
         source.write_text(json.dumps(payload), encoding="utf-8")
-        cases = datasets._parse_cases(payload, skill, source, errors)
+        cases = datasets._parse_cases(payload, skill, source, errors, extended)
     return cases, errors
 
 
@@ -333,6 +336,72 @@ class TestTier0(unittest.TestCase):
         errors = datasets.tier0_errors("no-such-skill", [])
         self.assertEqual(len(errors), 1)
         self.assertIn("no eval dataset", errors[0])
+
+
+class TestExtendedDataset(unittest.TestCase):
+    """The optional second dataset: same format, no bar, opt-in run."""
+
+    def write(self, payload: dict) -> Path:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        path = Path(tmp.name) / "extended_evals.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        return path
+
+    def load(self, payload: dict | None, *, extended: bool) -> list:
+        """Load `local-ai-use` with `payload` standing in for its extended file."""
+        path = self.write(payload) if payload is not None else Path("no-such-file")
+        original = datasets.extended_dataset_path
+        datasets.extended_dataset_path = lambda skill: path
+        try:
+            return datasets.load_dataset("local-ai-use", extended=extended)
+        finally:
+            datasets.extended_dataset_path = original
+
+    def payload(self) -> dict:
+        return {
+            EVALUATIONS_KEY: [
+                {
+                    "id": "extended-one",
+                    TRIGGER_KEY: True,
+                    "prompt": "p",
+                    "expected_behavior": ["do the thing"],
+                }
+            ]
+        }
+
+    def test_cases_are_added_only_when_asked_for(self) -> None:
+        required = {c.id for c in self.load(self.payload(), extended=False)}
+        both = {c.id for c in self.load(self.payload(), extended=True)}
+        self.assertNotIn("extended-one", required)
+        self.assertEqual(both - required, {"extended-one"})
+
+    def test_extended_cases_are_marked_and_others_are_not(self) -> None:
+        cases = {c.id: c for c in self.load(self.payload(), extended=True)}
+        self.assertTrue(cases["extended-one"].extended)
+        self.assertFalse(any(c.extended for c in cases.values() if c.id != "extended-one"))
+
+    def test_a_missing_file_is_not_an_error(self) -> None:
+        self.assertTrue(self.load(None, extended=True))
+
+    def test_extended_cases_do_not_count_towards_tier0(self) -> None:
+        # Otherwise a skill could clear the mandatory bar with prompts this
+        # repo never runs.
+        cases, errors = parse(
+            {EVALUATIONS_KEY: [{"id": c, TRIGGER_KEY: True, "prompt": "p"} for c in "abc"]
+             + [{"id": c, TRIGGER_KEY: False, "prompt": "p"} for c in "de"]},
+            skill="local-ai-use",
+            extended=True,
+        )
+        self.assertEqual(errors, [])
+        self.assertTrue(all(c.extended for c in cases))
+        self.assertTrue(datasets.tier0_errors("local-ai-use", [c for c in cases if not c.extended]))
+
+    def test_the_format_is_the_same_one(self) -> None:
+        # No separate parser, so an extended dataset is rejected for the same
+        # reasons the required one is.
+        _, errors = parse(triggers(prompt="p"), extended=True)
+        self.assertTrue(any("`id`" in e for e in errors), errors)
 
 
 class TestRepositoryDatasets(unittest.TestCase):


### PR DESCRIPTION
# Description

Skills can now ship a second eval dataset next to the required one, `evals/extended_evals.json`. This is for the product repo to test their skill beyond what we test here.

Additional changes are still needed to ensure we can easily share this harness with others using reusable workflows.