### PR TITLE
docs(lemonade-router-builder): clarify example policies are shape references, not runnable

### DIFF
--- a/skills/lemonade-router-builder/examples.md
+++ b/skills/lemonade-router-builder/examples.md
@@ -7,6 +7,19 @@ should produce. Note what was defaulted: names, ids, thresholds, `on_error`,
 is derived from the default candidate rather than a fixed literal, so the
 examples below each get a distinct name.
 
+**These are shape references, not runnable policies.** Each names models a
+given host may not have. They all pass `scripts/validate.py`, which
+deliberately cannot check model existence - that needs a live server. Register
+one against a host missing a referenced model and the server rejects it:
+
+```
+400 Collection component not registered: '<model>'.
+    Pull or register it before referencing it in a collection.
+```
+
+That is correct, documented behaviour. Substitute models the target host
+actually has (`GET /api/v1/models`) before registering.
+
 
 ## 1. Pure intent, no concrete signals → LLM-as-router
 


### PR DESCRIPTION
# Description

Follow-up to #151. Most of that PR's feedback (Mode A trace synthetic ids,
`default_used` vs. `rationale` as the fallback signal, classifier label
mismatches scoring `0.0` silently) was already addressed by #156, which is
now merged into `main`.

The one piece #156 didn't cover: `examples.md`'s bundled policies name models
a given host may not have. `scripts/validate.py` can't check model existence
(needs a live server), so registering one of these examples unmodified fails
at the server with `400 Collection component not registered`. This documents
that the examples are shape references, not runnable as-is, and that models
should be swapped for ones the target host actually has before registering.
