### PR TITLE
docs(conf): switch to rocm-ai flavor, enable repo and download buttons

### DIFF
--- a/docs/rocm-docs/conf.py
+++ b/docs/rocm-docs/conf.py
@@ -12,7 +12,11 @@ copyright = "Copyright (c) Advanced Micro Devices, Inc. All rights reserved."
 # -- General configuration -------------------------------------------------
 
 html_theme = "rocm_docs_theme"
-html_theme_options = {"flavor": "rocm"}
+html_theme_options = {
+    "flavor": "rocm-ai",
+    "use_repository_button": True,
+    "use_download_button": True,
+}
 html_title = "AMD Skills documentation"
 suppress_warnings = ["etoc.toctree"]
 external_toc_path = "./sphinx/_toc.yml"


### PR DESCRIPTION
Switches the AMD Skills docs theme flavor from `rocm` to `rocm-ai`, matching the ROCm CLI docs, and enables the repository and download buttons.