### PR TITLE
Use OIDC token federation

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -71,6 +71,11 @@ concurrency:
 
 permissions:
   contents: read
+  # Lets a job ask GitHub for an OIDC token, which the Instinct legs trade for a
+  # short-lived Anthropic one instead of reading a key. It grants nothing over
+  # the repository, and it has to be granted here rather than in the called
+  # workflow: a reusable workflow can only lower what its caller passed down.
+  id-token: write
 
 jobs:
   # Mark the `results` check this produces as required in branch protection.
@@ -79,7 +84,7 @@ jobs:
     # out at the commit this ref names and runs it from there, so bumping the
     # line below is the whole of upgrading -- there is no second version to keep
     # in step with it.
-    uses: amd/skillscope/.github/workflows/skill-evals.yml@v0.1.2
+    uses: amd/skillscope/.github/workflows/skill-evals.yml@v0.1.3
     # By name, not by value: the Instinct legs read a secret scoped to the
     # `behavioral-instinct` environment, and an environment's secrets are
     # readable only inside the job that declares it.
@@ -168,5 +173,18 @@ jobs:
         Ocp-Apim-Subscription-Key: $API_KEY
         user: a1_ucicd
 
-      # The Instinct environment holds a plain Anthropic key, so no gateway.
-      scoped_api_key_secret: ANTHROPIC_API_KEY
+      # The Instinct legs call api.anthropic.com directly, so they can federate
+      # instead of holding a key: each job trades its GitHub OIDC token for a
+      # short-lived Anthropic one. The gateway legs above cannot, because that
+      # token only authenticates at api.anthropic.com.
+      #
+      # These four are identifiers, not credentials -- the exchange only
+      # succeeds when they arrive with a JWT GitHub signed for this repository
+      # -- and the `secrets` context is not available in a job-level `with:`
+      # anyway. The rule is scoped on Anthropic's side to the subject these
+      # jobs present, `repo:amd/skills:environment:behavioral-instinct`.
+      scoped_api_key_secret: ""
+      scoped_federation_rule_id: fdrl_014u39zsJmsex5SkL1gWg7qo
+      scoped_federation_organization_id: 9bdff596-1595-4140-8301-817e43ef8412
+      scoped_federation_service_account_id: svac_016zcTqZ4XkFdjAJCag9jQC9
+      scoped_federation_workspace_id: wrkspc_01EUPtU7mqFtoQowMAREPvoq

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -71,10 +71,8 @@ concurrency:
 
 permissions:
   contents: read
-  # Lets a job ask GitHub for an OIDC token, which the Instinct legs trade for a
-  # short-lived Anthropic one instead of reading a key. It grants nothing over
-  # the repository, and it has to be granted here rather than in the called
-  # workflow: a reusable workflow can only lower what its caller passed down.
+  # Lets a job ask GitHub for an OIDC token, which is traded for a
+  # short-lived Anthropic one instead of reading a key.
   id-token: write
 
 jobs:
@@ -173,16 +171,9 @@ jobs:
         Ocp-Apim-Subscription-Key: $API_KEY
         user: a1_ucicd
 
-      # The Instinct legs call api.anthropic.com directly, so they can federate
-      # instead of holding a key: each job trades its GitHub OIDC token for a
-      # short-lived Anthropic one. The gateway legs above cannot, because that
-      # token only authenticates at api.anthropic.com.
-      #
-      # These four are identifiers, not credentials -- the exchange only
-      # succeeds when they arrive with a JWT GitHub signed for this repository
-      # -- and the `secrets` context is not available in a job-level `with:`
-      # anyway. The rule is scoped on Anthropic's side to the subject these
-      # jobs present, `repo:amd/skills:environment:behavioral-instinct`.
+      # Some runners talk straight to api.anthropic.com, so they can use GitHub OIDC tokens to get temporary Anthropic access instead of storing a key. 
+      # (The gateway runners above can't, since those tokens only work with api.anthropic.com.)
+      # The four fields below are just IDs—no secrets—and only work if GitHub sends a signed token from this repo.
       scoped_api_key_secret: ""
       scoped_federation_rule_id: fdrl_014u39zsJmsex5SkL1gWg7qo
       scoped_federation_organization_id: 9bdff596-1595-4140-8301-817e43ef8412


### PR DESCRIPTION
# Description

Swaps the stored `ANTHROPIC_API_KEY` for OIDC-based federation. Each job mints a short-lived Anthropic token from its own GitHub OIDC token instead of pulling a long-lived secret. One file, three changes: blank out the key, add id-token: write, bump the harness pin.